### PR TITLE
feat: 支持 omp(Oh My Pi) 作为第三个执行引擎

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ cd frontend && npm run build    # 产物在 frontend/dist
 6. 「统计」看任务趋势 / 引擎用量 / 问题态势
 
 选用 omp 时，「设置 → Oh My Pi」可以填模型、思考档位，以及任意 omp 原生参数（如 `--advisor --max-time 30m`）——参数按 shell 词法拆成 argv 直接传给 omp，不经过 shell。
-会改变 omp 会话存储位置的参数（`--session-dir` / `--profile` / `--no-session` 等）会被拒绝，否则 Bosun 无法捕获会话 id，续跑、历史与用量统计都会失效。
+下列参数会被拒绝：改变会话存储位置的（`--session-dir` / `--profile` / `--no-session`）、由 Bosun 决定运行方式的（`--resume` / `-p` / `--mode` / `--auto-approve` / `--from-claude` 等）、会导致 omp 加载不到 `bosun-report` 的（`--no-skills` / `--no-tools` / `--skills`），以及携带密钥的（`--api-key`，请改用环境变量）。
 
 ## 配置
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,7 @@ cd frontend && npm run build    # 产物在 frontend/dist
 5. 「整体分析」→ 问题收件箱 → 勾「→ 修复任务」转成修复任务（人在环）
 6. 「统计」看任务趋势 / 引擎用量 / 问题态势
 
-选用 omp 时，「设置 → Oh My Pi」可以填模型、思考档位，以及任意 omp 原生参数（如 `--advisor --max-time 30m`）——参数按 shell 词法拆成 argv 直接传给 omp，不经过 shell。
-下列参数会被拒绝：改变会话存储位置的（`--session-dir` / `--profile` / `--no-session`）、由 Bosun 决定运行方式的（`--resume` / `-p` / `--mode` / `--auto-approve` / `--from-claude` 等）、会导致 omp 加载不到 `bosun-report` 的（`--no-skills` / `--no-tools` / `--skills`），以及携带密钥的（`--api-key`，请改用环境变量）。
+选用 omp 时，「设置 → Oh My Pi」可以填模型与思考档位。
 
 ## 配置
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ cd frontend && npm run build    # 产物在 frontend/dist
 5. 「整体分析」→ 问题收件箱 → 勾「→ 修复任务」转成修复任务（人在环）
 6. 「统计」看任务趋势 / 引擎用量 / 问题态势
 
+选用 omp 时，「设置 → Oh My Pi」可以填模型、思考档位，以及任意 omp 原生参数（如 `--advisor --max-time 30m`）——参数按 shell 词法拆成 argv 直接传给 omp，不经过 shell。
+
 ## 配置
 
 | 环境变量 | 默认值 | 用途 |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bosun 是一个本地优先的 Web 工作台，用来扫描和管理本机多个
 ## 核心能力
 
 - 扫描本机目录并集中管理多个项目
-- 在 Claude Code 和 Codex 之间选择执行引擎，创建、排队和接续任务
+- 在 Claude Code、Codex 和 Oh My Pi 之间选择执行引擎，创建、排队和接续任务
 - 通过优先级与并发上限自动调度任务
 - 在浏览器中查看实时终端、输入指令并接管会话
 - 汇总问题、任务趋势、引擎用量与复盘数据
@@ -48,6 +48,7 @@ _以上截图使用完全虚构的项目、路径、任务、终端输出和系�
 - Node.js 18+ 与 npm
 - Git
 - 已安装并登录 `claude`（Claude Code）和/或 `codex` CLI，且命令位于 `PATH` 中
+- 可选：`omp`（[Oh My Pi](https://github.com/can1357/oh-my-pi)，`npm i -g @oh-my-pi/pi-coding-agent`）。它自带 provider 凭据、依赖 Bun 运行时，安装体积约 1.1 GB；Bosun 不为它做订阅额度查询
 
 ### 安装
 
@@ -132,7 +133,7 @@ cd frontend && npm run build    # 产物在 frontend/dist
 ## 用法
 
 1. 右上「+ 项目 / 扫描」→ 填一个根目录扫描导入，或手动加单个仓库
-2. 项目泳道里「+ 任务」→ 选 cc/codex + 写指令 + 优先级 → 自动进调度
+2. 项目泳道里「+ 任务」→ 选 cc/codex/omp + 写指令 + 优先级 → 自动进调度
 3. 点任务卡「终端」→ 右侧实时终端，可打字插手
 4. 拖拽任务卡改优先级；顶栏调并发上限
 5. 「整体分析」→ 问题收件箱 → 勾「→ 修复任务」转成修复任务（人在环）
@@ -148,12 +149,16 @@ cd frontend && npm run build    # 产物在 frontend/dist
 | `BOSUN_PASSWORD` | 未设置 | 访问口令；设置后会覆盖设置页中保存的口令 |
 | `BOSUN_BACKEND_PORT` | `8770` | `start.sh` 使用的后端端口 |
 | `BOSUN_FRONTEND_PORT` | `5199` | `start.sh` 开发模式使用的前端端口 |
+| `BOSUN_CLAUDE_BIN` | 自动探测 `claude` | Claude Code 可执行文件路径 |
+| `BOSUN_CODEX_BIN` | 自动探测 `codex` | Codex CLI 可执行文件路径 |
+| `BOSUN_OMP_BIN` | 自动探测 `omp` | Oh My Pi 可执行文件路径 |
 
 默认数据保存在 `~/.bosun/`。升级或迁移前，建议先备份该目录。
 
 ## 安全说明
 
-- Bosun 会继承本机 Claude Code / Codex 的登录状态和文件访问能力，请只导入可信仓库。
+- Bosun 会继承本机 Claude Code / Codex / Oh My Pi 的登录状态和文件访问能力，请只导入可信仓库。
+- Oh My Pi 启动时会自动读取 `~/.claude` 下的配置，包括已配置的 MCP server 和 skills；不希望它接触这些资源时，不要选用该引擎。
 - 未设置访问口令时，任何能访问服务的人都可能操作任务和终端；局域网环境也不应视为安全边界。
 - 若需跨设备访问，至少启用强口令；若需公网访问，请额外使用 HTTPS、可信反向代理和网络访问控制。
 - 不要把 API Key、访问令牌、数据库或 `~/.bosun/` 中的运行数据提交到 Git。

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ cd frontend && npm run build    # 产物在 frontend/dist
 6. 「统计」看任务趋势 / 引擎用量 / 问题态势
 
 选用 omp 时，「设置 → Oh My Pi」可以填模型、思考档位，以及任意 omp 原生参数（如 `--advisor --max-time 30m`）——参数按 shell 词法拆成 argv 直接传给 omp，不经过 shell。
+会改变 omp 会话存储位置的参数（`--session-dir` / `--profile` / `--no-session` 等）会被拒绝，否则 Bosun 无法捕获会话 id，续跑、历史与用量统计都会失效。
 
 ## 配置
 

--- a/backend/app/autopilot.py
+++ b/backend/app/autopilot.py
@@ -227,10 +227,14 @@ def assistant_text(engine: str, stdout: str) -> str:
             if isinstance(msg, dict) and msg.get("role") == "assistant":
                 parts.append(_text_blocks(msg.get("content")))
             continue
-        # codex exec --json：助手可见输出走 agent_message 事件
-        payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else obj
-        if payload.get("type") == "agent_message" and isinstance(payload.get("message"), str):
-            parts.append(payload["message"])
+        # codex exec --json：助手正文在 item.completed 事件里(实测 codex-cli 0.146.0)
+        #   {"type":"item.completed","item":{"type":"agent_message","text":"..."}}
+        if obj.get("type") == "item.completed":
+            item = obj.get("item")
+            if isinstance(item, dict) and item.get("type") == "agent_message":
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
     return "\n".join(p for p in parts if p).strip()
 
 

--- a/backend/app/autopilot.py
+++ b/backend/app/autopilot.py
@@ -178,6 +178,62 @@ def _verify(project) -> tuple[str, str]:
     return ("pass", " ".join(ran)) if ran else ("skip", "(无验证命令)")
 
 
+def _text_blocks(content) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    return "\n".join(parts)
+
+
+def assistant_text(engine: str, stdout: str) -> str:
+    """从 headless 的结构化输出里抽出助手正文，丢掉被回显的用户提示词。
+
+    结论判定必须基于这段正文：原始事件流里既有用户提示词也有 diff 原文，
+    对它做 PASS/FAIL 正则会读到别人的字。
+    """
+    import json
+
+    if engine == "cc":
+        try:
+            parsed = json.loads(stdout)
+        except (json.JSONDecodeError, TypeError):
+            return stdout
+        text = parsed.get("result") or parsed.get("text") if isinstance(parsed, dict) else None
+        return text if isinstance(text, str) else stdout
+
+    parts: list[str] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if engine == "omp":
+            # omp --mode json：同一条消息会在多种事件里重复出现，只认 message_end
+            if obj.get("type") != "message_end":
+                continue
+            msg = obj.get("message")
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                parts.append(_text_blocks(msg.get("content")))
+            continue
+        # codex exec --json：助手可见输出走 agent_message 事件
+        payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else obj
+        if payload.get("type") == "agent_message" and isinstance(payload.get("message"), str):
+            parts.append(payload["message"])
+    return "\n".join(p for p in parts if p).strip()
+
+
 def _cross_review(run_id: int, engine: str, cwd: str, diff: str) -> tuple[str, str]:
     """返回 (verdict, note)，verdict ∈ pass|fail|unknown。
 
@@ -192,6 +248,9 @@ def _cross_review(run_id: int, engine: str, cwd: str, diff: str) -> tuple[str, s
     code, out, _ = _headless(run_id, engine, prompt, cwd, REVIEW_TIMEOUT)
     if code != 0:
         return "unknown", "(复审未运行)"
+    # headless 是结构化输出(json_out=True)，原始流里还夹着被回显的用户提示词。
+    # 直接正则会先撞上提示词里的「PASS 或 FAIL」，把 FAIL 的复审读成 PASS。
+    out = assistant_text(engine, out) or out
     up = out.upper()
     # 锚定行首优先(复审结论), 回退全局; 避免 diff 内 PASS/FAIL 字样或复述指令污染结论
     m = re.search(r"^\s*(PASS|FAIL)", up, re.M) or re.search(r"\b(PASS|FAIL)\b", up)

--- a/backend/app/autopilot.py
+++ b/backend/app/autopilot.py
@@ -48,6 +48,26 @@ def _parse_tokens(engine: str, stdout: str) -> int:
         except (json.JSONDecodeError, TypeError):
             return 0
         return sum(v for k, v in u.items() if isinstance(v, int) and k in ("input_tokens", "output_tokens"))
+    if engine == "omp":
+        # omp --mode json 是逐事件 NDJSON，每条消息自带增量 usage。同一条消息会在
+        # message_start/message_end/turn_end/agent_end 里重复出现，只认 message_end
+        # 累加，否则会重复计数。
+        total = 0
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "message_end":
+                continue
+            msg = obj.get("message")
+            u = msg.get("usage") if isinstance(msg, dict) else None
+            if isinstance(u, dict):
+                total += sum(v for k, v in u.items() if isinstance(v, int) and k in ("input", "output"))
+        return total
     # codex JSONL：逐事件找含 token 的 usage，取累计最大
     best = 0
     for line in stdout.splitlines():

--- a/backend/app/autopilot.py
+++ b/backend/app/autopilot.py
@@ -238,6 +238,22 @@ def assistant_text(engine: str, stdout: str) -> str:
     return "\n".join(p for p in parts if p).strip()
 
 
+def _looks_structured(stdout: str) -> bool:
+    """输出里是否存在成行的 JSON 事件(用于区分「结构化但没抽到」和「本来就是纯文本」)。"""
+    import json
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        return True
+    return False
+
+
 def _cross_review(run_id: int, engine: str, cwd: str, diff: str) -> tuple[str, str]:
     """返回 (verdict, note)，verdict ∈ pass|fail|unknown。
 
@@ -254,7 +270,15 @@ def _cross_review(run_id: int, engine: str, cwd: str, diff: str) -> tuple[str, s
         return "unknown", "(复审未运行)"
     # headless 是结构化输出(json_out=True)，原始流里还夹着被回显的用户提示词。
     # 直接正则会先撞上提示词里的「PASS 或 FAIL」，把 FAIL 的复审读成 PASS。
-    out = assistant_text(engine, out) or out
+    extracted = assistant_text(engine, out)
+    if not extracted.strip():
+        if _looks_structured(out):
+            # 事件流在那儿但抽不出助手正文：空响应 / NDJSON 截断 / CLI 换了 schema。
+            # 退回扫原始流就会读到被回显的提示词，宁可判 unknown(不放行)。
+            return "unknown", "(复审输出无法解析)"
+        # 纯文本输出(如 SDK 返回)里没有回显的提示词，按原文判定是安全的
+    else:
+        out = extracted
     up = out.upper()
     # 锚定行首优先(复审结论), 回退全局; 避免 diff 内 PASS/FAIL 字样或复述指令污染结论
     m = re.search(r"^\s*(PASS|FAIL)", up, re.M) or re.search(r"\b(PASS|FAIL)\b", up)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -107,3 +107,12 @@ CODEX_BIN = _resolve_bin(
         Path("/usr/local/bin/codex"),
     ],
 )
+OMP_BIN = _resolve_bin(
+    "BOSUN_OMP_BIN",
+    "omp",
+    [
+        Path.home() / ".local" / "bin" / "omp",
+        Path("/opt/homebrew/bin/omp"),
+        Path("/usr/local/bin/omp"),
+    ],
+)

--- a/backend/app/engine_models.py
+++ b/backend/app/engine_models.py
@@ -181,6 +181,10 @@ def refresh_model_options(engine: str, binary: str) -> list[dict[str, str]]:
         options = discover_claude_model_options(binary)
     elif engine == "codex":
         options = discover_codex_model_options(binary)
+    elif engine == "omp":
+        # omp 的 --model 是跨 provider 的模糊匹配，没有可直接消费的目录接口；
+        # 设置页可以直接填模型 ID，这里明确告知而不是抛未知引擎。
+        raise ModelDiscoveryError("omp 暂不支持自动刷新模型列表，可直接填写模型 ID")
     else:
         raise ValueError(f"unknown engine: {engine}")
     db.set_setting(_SETTING_KEYS[engine], json.dumps(options, ensure_ascii=False))

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -223,6 +223,30 @@ OMP_SESSION_RELOCATING_ARGS = {
     "--no-session",
 }
 
+# Bosun 自己决定的调用方式：由这里统一拼，用户覆盖会直接改变任务语义。
+# 例如配上 --resume，每个新任务都会去续别人的会话，且因为那份 transcript 已在
+# snapshot 里，Bosun 永远捕获不到会话 id。
+OMP_RUNTIME_OWNED_ARGS = {
+    "--resume", "-r",
+    "--continue", "-c",
+    "--print", "-p",
+    "--mode",
+    "--auto-approve",
+    "--approval-mode",
+    "--cwd",
+    "--export",
+}
+
+
+# 不带值的开关，用于区分「选项的值」和「位置参数」。名单之外的选项一律按带值处理，
+# 顶多把一个开关后面的下一项少校验一次，不会误伤合法配置。
+_OMP_BOOLEAN_ARGS = {
+    "--advisor", "--no-lsp", "--no-pty", "--no-tools", "--no-extensions",
+    "--no-skills", "--no-rules", "--no-title", "--hide-thinking",
+    "--prewalk", "--no-prewalk", "--plan-yolo", "--allow-home",
+    "--print-thoughts",
+}
+
 
 class OmpExtraArgsError(ValueError):
     """自定义参数无法使用，附带给用户看的原因。"""
@@ -237,13 +261,28 @@ def validate_omp_extra_args(value: object) -> str:
         argv = shlex.split(raw)
     except ValueError as exc:
         raise OmpExtraArgsError(f"参数无法解析(引号是否配对？)：{exc}") from exc
+    expects_value = False
     for token in argv:
+        if expects_value:
+            expects_value = False
+            continue
+        if not token.startswith("-"):
+            raise OmpExtraArgsError(
+                f"不允许填位置参数 {token!r}：任务指令由任务本身提供，"
+                "这里只接受选项"
+            )
         name = token.split("=", 1)[0]
         if name in OMP_SESSION_RELOCATING_ARGS:
             raise OmpExtraArgsError(
                 f"不允许使用 {name}：它会改变 omp 的会话存储位置，"
                 "Bosun 将无法捕获会话 id，续跑、历史与用量统计都会失效"
             )
+        if name in OMP_RUNTIME_OWNED_ARGS:
+            raise OmpExtraArgsError(
+                f"不允许使用 {name}：运行方式(续跑/审批/输出格式)由 Bosun 按任务决定"
+            )
+        # 形如 `--flag value` 的选项，下一个 token 是它的值，不该当成位置参数
+        expects_value = "=" not in token and name not in _OMP_BOOLEAN_ARGS
     return raw
 
 

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -263,15 +263,9 @@ def validate_omp_extra_args(value: object) -> str:
         raise OmpExtraArgsError(f"参数无法解析(引号是否配对？)：{exc}") from exc
     expects_value = False
     for token in argv:
-        if expects_value:
-            expects_value = False
-            continue
-        if not token.startswith("-"):
-            raise OmpExtraArgsError(
-                f"不允许填位置参数 {token!r}：任务指令由任务本身提供，"
-                "这里只接受选项"
-            )
         name = token.split("=", 1)[0]
+        # 先查禁用名再决定是否当作上一个选项的值：否则 `--help --no-session` 里
+        # 的 --no-session 会被当成 --help 的值跳过校验。
         if name in OMP_SESSION_RELOCATING_ARGS:
             raise OmpExtraArgsError(
                 f"不允许使用 {name}：它会改变 omp 的会话存储位置，"
@@ -280,6 +274,14 @@ def validate_omp_extra_args(value: object) -> str:
         if name in OMP_RUNTIME_OWNED_ARGS:
             raise OmpExtraArgsError(
                 f"不允许使用 {name}：运行方式(续跑/审批/输出格式)由 Bosun 按任务决定"
+            )
+        if expects_value:
+            expects_value = False
+            continue
+        if not token.startswith("-"):
+            raise OmpExtraArgsError(
+                f"不允许填位置参数 {token!r}：任务指令由任务本身提供，"
+                "这里只接受选项"
             )
         # 形如 `--flag value` 的选项，下一个 token 是它的值，不该当成位置参数
         expects_value = "=" not in token and name not in _OMP_BOOLEAN_ARGS

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import shlex
 
 from . import codex_skills_guard, db
 
@@ -214,136 +213,8 @@ def omp_thinking_options() -> list[dict[str, str]]:
     return [dict(opt) for opt in OMP_THINKING_OPTIONS]
 
 
-# 会把 transcript 写到 Bosun 找不到的地方的参数：会话目录一旦被改写，
-# 捕获/续跑/历史/token 结算会全部静默失效，所以直接拒绝而不是事后排查。
-OMP_SESSION_RELOCATING_ARGS = {
-    "--session-dir",
-    "--profile",
-    "--alias",
-    "--no-session",
-}
-
-# Bosun 自己决定的调用方式：由这里统一拼，用户覆盖会直接改变任务语义。
-# 例如配上 --resume，每个新任务都会去续别人的会话，且因为那份 transcript 已在
-# snapshot 里，Bosun 永远捕获不到会话 id。
-OMP_RUNTIME_OWNED_ARGS = {
-    "--resume", "-r",
-    "--continue", "-c",
-    "--print", "-p",
-    "--mode",
-    "--auto-approve",
-    "--approval-mode",
-    "--cwd",
-    "--export",
-    # 导入模式：会把每次派发都变成「续别人的会话」而不是新建
-    "--from-claude", "--from-codex",
-}
-
-# 会让 omp 加载不到 bosun-report skill 的参数。任务因此永远报不了完成，
-# 又因为等待判定默认关闭，会一直挂在 running 占着并发槽。
-OMP_REPORTING_BREAKING_ARGS = {
-    "--no-skills",
-    "--no-tools",
-    "--skills",          # 按 glob 过滤，可能把 bosun-report 滤掉
-    "--no-extensions",
-}
-
-# 凭据类参数：设置项会落库、经 GET /api/settings 回给前端，还会出现在进程 argv 里。
-# 团队规范要求密钥只走环境变量或密钥服务。
-OMP_CREDENTIAL_ARGS = {"--api-key"}
-
-
-# 不带值的开关，用于区分「选项的值」和「位置参数」。名单之外的选项一律按带值处理，
-# 顶多把一个开关后面的下一项少校验一次，不会误伤合法配置。
-_OMP_BOOLEAN_ARGS = {
-    "--advisor", "--no-lsp", "--no-pty", "--no-rules", "--no-title",
-    "--hide-thinking", "--prewalk", "--no-prewalk", "--plan-yolo",
-    "--allow-home", "--print-thoughts",
-}
-
-
-class OmpExtraArgsError(ValueError):
-    """自定义参数无法使用，附带给用户看的原因。"""
-
-
-def validate_omp_extra_args(value: object) -> str:
-    """校验并返回自定义参数原文。不合法时抛 OmpExtraArgsError。"""
-    raw = str(value or "").strip()
-    if not raw:
-        return ""
-    try:
-        argv = shlex.split(raw)
-    except ValueError as exc:
-        raise OmpExtraArgsError(f"参数无法解析(引号是否配对？)：{exc}") from exc
-    expects_value = False
-    for token in argv:
-        name = token.split("=", 1)[0]
-        # 先查禁用名再决定是否当作上一个选项的值：否则 `--help --no-session` 里
-        # 的 --no-session 会被当成 --help 的值跳过校验。
-        if name in OMP_SESSION_RELOCATING_ARGS:
-            raise OmpExtraArgsError(
-                f"不允许使用 {name}：它会改变 omp 的会话存储位置，"
-                "Bosun 将无法捕获会话 id，续跑、历史与用量统计都会失效"
-            )
-        if name in OMP_RUNTIME_OWNED_ARGS:
-            raise OmpExtraArgsError(
-                f"不允许使用 {name}：运行方式(续跑/审批/输出格式)由 Bosun 按任务决定"
-            )
-        if name in OMP_REPORTING_BREAKING_ARGS:
-            raise OmpExtraArgsError(
-                f"不允许使用 {name}：omp 会因此加载不到 bosun-report skill，"
-                "任务永远报不了完成，会一直挂在运行中占用并发槽"
-            )
-        if name in OMP_CREDENTIAL_ARGS:
-            raise OmpExtraArgsError(
-                f"不允许在这里填 {name}：设置会落库并回传前端，密钥还会出现在进程参数里。"
-                "请改用环境变量或密钥服务"
-            )
-        if expects_value:
-            expects_value = False
-            continue
-        if not token.startswith("-"):
-            raise OmpExtraArgsError(
-                f"不允许填位置参数 {token!r}：任务指令由任务本身提供，"
-                "这里只接受选项"
-            )
-        # 形如 `--flag value` 的选项，下一个 token 是它的值，不该当成位置参数
-        expects_value = "=" not in token and name not in _OMP_BOOLEAN_ARGS
-    if expects_value:
-        # 末尾选项缺值时，build_argv 会把任务指令接在它后面当成值吃掉
-        raise OmpExtraArgsError(f"{argv[-1]} 缺少取值：否则任务指令会被当成它的值")
-    return raw
-
-
-def normalize_omp_extra_args(value: object) -> str:
-    """读取侧的宽松归一：拿不下的值当没配，绝不因为一个坏设置就起不了任务。"""
-    try:
-        return validate_omp_extra_args(value)
-    except OmpExtraArgsError:
-        return ""
-
-
-def omp_extra_args() -> str:
-    return normalize_omp_extra_args(db.get_setting("omp_extra_args", ""))
-
-
-def omp_extra_argv() -> list[str]:
-    """把设置里的自定义参数拆成 argv。
-
-    参数是拆成 argv 直接 exec 的，不经过 shell，所以不存在命令注入；但仍然禁止
-    在这里塞位置参数(prompt)，否则会和任务指令抢位置。
-    """
-    raw = omp_extra_args()
-    if not raw:
-        return []
-    try:
-        return shlex.split(raw)
-    except ValueError:
-        return []
-
-
 def with_omp_runtime_args(argv: list[str]) -> list[str]:
-    """omp 的模型/思考档位/自定义参数插在可执行文件之后、其余参数之前。
+    """omp 的模型与思考档位插在可执行文件之后、其余参数之前。
 
     argv 里可能已经带上了 prompt(如 build_audit_argv)，追加到末尾会让 flag 落在
     位置参数后面，所以统一按前缀插入。
@@ -357,8 +228,6 @@ def with_omp_runtime_args(argv: list[str]) -> list[str]:
     thinking = omp_thinking()
     if thinking:
         prefix += ["--thinking", thinking]
-    # 自定义参数放最后：同名 flag 由用户显式覆盖上面两项
-    prefix += omp_extra_argv()
     return [*prefix, *argv[1:]]
 
 

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 
 from . import codex_skills_guard, db
 
@@ -213,8 +214,39 @@ def omp_thinking_options() -> list[dict[str, str]]:
     return [dict(opt) for opt in OMP_THINKING_OPTIONS]
 
 
+def normalize_omp_extra_args(value: object) -> str:
+    """自定义参数存原文，但先校验能被 shell 词法解析，避免存进去才发现引号不配对。"""
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        shlex.split(raw)
+    except ValueError:
+        return ""
+    return raw
+
+
+def omp_extra_args() -> str:
+    return normalize_omp_extra_args(db.get_setting("omp_extra_args", ""))
+
+
+def omp_extra_argv() -> list[str]:
+    """把设置里的自定义参数拆成 argv。拆不动就当没配，不阻断任务启动。
+
+    参数是拆成 argv 直接 exec 的，不经过 shell，所以不存在命令注入；但仍然禁止
+    在这里塞位置参数(prompt)，否则会和任务指令抢位置。
+    """
+    raw = omp_extra_args()
+    if not raw:
+        return []
+    try:
+        return shlex.split(raw)
+    except ValueError:
+        return []
+
+
 def with_omp_runtime_args(argv: list[str]) -> list[str]:
-    """omp 的模型/思考档位插在可执行文件之后、其余参数之前。
+    """omp 的模型/思考档位/自定义参数插在可执行文件之后、其余参数之前。
 
     argv 里可能已经带上了 prompt(如 build_audit_argv)，追加到末尾会让 flag 落在
     位置参数后面，所以统一按前缀插入。
@@ -228,6 +260,8 @@ def with_omp_runtime_args(argv: list[str]) -> list[str]:
     thinking = omp_thinking()
     if thinking:
         prefix += ["--thinking", thinking]
+    # 自定义参数放最后：同名 flag 由用户显式覆盖上面两项
+    prefix += omp_extra_argv()
     return [*prefix, *argv[1:]]
 
 

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -163,6 +163,74 @@ def with_codex_runtime_args(argv: list[str]) -> list[str]:
     return [*prefix, *argv[1:]]
 
 
+# ---- omp(Oh My Pi)模型与思考档位 ----
+# omp 的 --model 做模糊匹配("opus" / "gpt-5.6" / "openai/gpt-5.2" 都接受)，
+# 所以内置项只是常用建议，settings 里同样允许填任意自定义模型 ID。
+OMP_MODEL_OPTIONS = [
+    {"value": "", "label": "默认"},
+    {"value": "opus", "label": "Opus"},
+    {"value": "sonnet", "label": "Sonnet"},
+    {"value": "gpt-5.6", "label": "gpt-5.6"},
+    {"value": "gemini", "label": "Gemini"},
+]
+# 对应 omp --thinking 的取值
+OMP_THINKING_OPTIONS = [
+    {"value": "", "label": "默认"},
+    {"value": "off", "label": "Off"},
+    {"value": "minimal", "label": "Minimal"},
+    {"value": "low", "label": "Low"},
+    {"value": "medium", "label": "Medium"},
+    {"value": "high", "label": "High"},
+    {"value": "xhigh", "label": "XHigh"},
+    {"value": "max", "label": "Max"},
+    {"value": "auto", "label": "Auto"},
+]
+_OMP_THINKING_VALUES = {opt["value"] for opt in OMP_THINKING_OPTIONS}
+
+
+def normalize_omp_model(value: object) -> str:
+    return str(value or "").strip()
+
+
+def omp_model() -> str:
+    return normalize_omp_model(db.get_setting("omp_model", ""))
+
+
+def omp_model_options() -> list[dict[str, str]]:
+    return _cached_model_options("omp_model_options", OMP_MODEL_OPTIONS)
+
+
+def normalize_omp_thinking(value: object) -> str:
+    raw = str(value or "").strip().lower()
+    return raw if raw in _OMP_THINKING_VALUES else ""
+
+
+def omp_thinking() -> str:
+    return normalize_omp_thinking(db.get_setting("omp_thinking", ""))
+
+
+def omp_thinking_options() -> list[dict[str, str]]:
+    return [dict(opt) for opt in OMP_THINKING_OPTIONS]
+
+
+def with_omp_runtime_args(argv: list[str]) -> list[str]:
+    """omp 的模型/思考档位插在可执行文件之后、其余参数之前。
+
+    argv 里可能已经带上了 prompt(如 build_audit_argv)，追加到末尾会让 flag 落在
+    位置参数后面，所以统一按前缀插入。
+    """
+    if not argv:
+        return argv
+    prefix = [argv[0]]
+    model = omp_model()
+    if model:
+        prefix += ["--model", model]
+    thinking = omp_thinking()
+    if thinking:
+        prefix += ["--thinking", thinking]
+    return [*prefix, *argv[1:]]
+
+
 def should_use_claude_sdk(
     engine: str,
     resume: bool,

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -235,16 +235,30 @@ OMP_RUNTIME_OWNED_ARGS = {
     "--approval-mode",
     "--cwd",
     "--export",
+    # 导入模式：会把每次派发都变成「续别人的会话」而不是新建
+    "--from-claude", "--from-codex",
 }
+
+# 会让 omp 加载不到 bosun-report skill 的参数。任务因此永远报不了完成，
+# 又因为等待判定默认关闭，会一直挂在 running 占着并发槽。
+OMP_REPORTING_BREAKING_ARGS = {
+    "--no-skills",
+    "--no-tools",
+    "--skills",          # 按 glob 过滤，可能把 bosun-report 滤掉
+    "--no-extensions",
+}
+
+# 凭据类参数：设置项会落库、经 GET /api/settings 回给前端，还会出现在进程 argv 里。
+# 团队规范要求密钥只走环境变量或密钥服务。
+OMP_CREDENTIAL_ARGS = {"--api-key"}
 
 
 # 不带值的开关，用于区分「选项的值」和「位置参数」。名单之外的选项一律按带值处理，
 # 顶多把一个开关后面的下一项少校验一次，不会误伤合法配置。
 _OMP_BOOLEAN_ARGS = {
-    "--advisor", "--no-lsp", "--no-pty", "--no-tools", "--no-extensions",
-    "--no-skills", "--no-rules", "--no-title", "--hide-thinking",
-    "--prewalk", "--no-prewalk", "--plan-yolo", "--allow-home",
-    "--print-thoughts",
+    "--advisor", "--no-lsp", "--no-pty", "--no-rules", "--no-title",
+    "--hide-thinking", "--prewalk", "--no-prewalk", "--plan-yolo",
+    "--allow-home", "--print-thoughts",
 }
 
 
@@ -274,6 +288,16 @@ def validate_omp_extra_args(value: object) -> str:
         if name in OMP_RUNTIME_OWNED_ARGS:
             raise OmpExtraArgsError(
                 f"不允许使用 {name}：运行方式(续跑/审批/输出格式)由 Bosun 按任务决定"
+            )
+        if name in OMP_REPORTING_BREAKING_ARGS:
+            raise OmpExtraArgsError(
+                f"不允许使用 {name}：omp 会因此加载不到 bosun-report skill，"
+                "任务永远报不了完成，会一直挂在运行中占用并发槽"
+            )
+        if name in OMP_CREDENTIAL_ARGS:
+            raise OmpExtraArgsError(
+                f"不允许在这里填 {name}：设置会落库并回传前端，密钥还会出现在进程参数里。"
+                "请改用环境变量或密钥服务"
             )
         if expects_value:
             expects_value = False

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -285,6 +285,9 @@ def validate_omp_extra_args(value: object) -> str:
             )
         # 形如 `--flag value` 的选项，下一个 token 是它的值，不该当成位置参数
         expects_value = "=" not in token and name not in _OMP_BOOLEAN_ARGS
+    if expects_value:
+        # 末尾选项缺值时，build_argv 会把任务指令接在它后面当成值吃掉
+        raise OmpExtraArgsError(f"{argv[-1]} 缺少取值：否则任务指令会被当成它的值")
     return raw
 
 

--- a/backend/app/engine_settings.py
+++ b/backend/app/engine_settings.py
@@ -214,16 +214,45 @@ def omp_thinking_options() -> list[dict[str, str]]:
     return [dict(opt) for opt in OMP_THINKING_OPTIONS]
 
 
-def normalize_omp_extra_args(value: object) -> str:
-    """自定义参数存原文，但先校验能被 shell 词法解析，避免存进去才发现引号不配对。"""
+# 会把 transcript 写到 Bosun 找不到的地方的参数：会话目录一旦被改写，
+# 捕获/续跑/历史/token 结算会全部静默失效，所以直接拒绝而不是事后排查。
+OMP_SESSION_RELOCATING_ARGS = {
+    "--session-dir",
+    "--profile",
+    "--alias",
+    "--no-session",
+}
+
+
+class OmpExtraArgsError(ValueError):
+    """自定义参数无法使用，附带给用户看的原因。"""
+
+
+def validate_omp_extra_args(value: object) -> str:
+    """校验并返回自定义参数原文。不合法时抛 OmpExtraArgsError。"""
     raw = str(value or "").strip()
     if not raw:
         return ""
     try:
-        shlex.split(raw)
-    except ValueError:
-        return ""
+        argv = shlex.split(raw)
+    except ValueError as exc:
+        raise OmpExtraArgsError(f"参数无法解析(引号是否配对？)：{exc}") from exc
+    for token in argv:
+        name = token.split("=", 1)[0]
+        if name in OMP_SESSION_RELOCATING_ARGS:
+            raise OmpExtraArgsError(
+                f"不允许使用 {name}：它会改变 omp 的会话存储位置，"
+                "Bosun 将无法捕获会话 id，续跑、历史与用量统计都会失效"
+            )
     return raw
+
+
+def normalize_omp_extra_args(value: object) -> str:
+    """读取侧的宽松归一：拿不下的值当没配，绝不因为一个坏设置就起不了任务。"""
+    try:
+        return validate_omp_extra_args(value)
+    except OmpExtraArgsError:
+        return ""
 
 
 def omp_extra_args() -> str:
@@ -231,7 +260,7 @@ def omp_extra_args() -> str:
 
 
 def omp_extra_argv() -> list[str]:
-    """把设置里的自定义参数拆成 argv。拆不动就当没配，不阻断任务启动。
+    """把设置里的自定义参数拆成 argv。
 
     参数是拆成 argv 直接 exec 的，不经过 shell，所以不存在命令注入；但仍然禁止
     在这里塞位置参数(prompt)，否则会和任务指令抢位置。

--- a/backend/app/engine_updates.py
+++ b/backend/app/engine_updates.py
@@ -49,6 +49,13 @@ _SPECS: dict[str, ToolSpec] = {
         binary=lambda: config.CODEX_BIN,
         npm_packages=("@openai/codex",),
     ),
+    "omp": ToolSpec(
+        engine="omp",
+        label="Oh My Pi",
+        binary=lambda: config.OMP_BIN,
+        npm_packages=("@oh-my-pi/pi-coding-agent",),
+        cli_update_args=("update",),
+    ),
 }
 
 _UPDATE_LOCKS = {engine: threading.Lock() for engine in _SPECS}

--- a/backend/app/engine_updates.py
+++ b/backend/app/engine_updates.py
@@ -27,6 +27,9 @@ class ToolSpec:
     binary: Callable[[], str]
     npm_packages: tuple[str, ...]
     cli_update_args: tuple[str, ...] = ()
+    # 该引擎是否有可消费的模型目录。没有的话更新后别去刷，免得把「本来就没有」
+    # 报成刷新失败。
+    has_model_catalog: bool = True
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,7 @@ _SPECS: dict[str, ToolSpec] = {
         binary=lambda: config.OMP_BIN,
         npm_packages=("@oh-my-pi/pi-coding-agent",),
         cli_update_args=("update",),
+        has_model_catalog=False,
     ),
 }
 
@@ -109,6 +113,8 @@ def _resolve_binary(binary: str) -> str | None:
 
 def _refresh_model_options(result: dict, engine: str, binary: str | None) -> dict:
     if not result.get("ok") or not binary:
+        return result
+    if not _spec(engine).has_model_catalog:
         return result
     try:
         result["model_options"] = engine_models.refresh_model_options(engine, binary)

--- a/backend/app/engines.py
+++ b/backend/app/engines.py
@@ -2,13 +2,14 @@
 
 cc  = Claude Code CLI (`claude`)：支持 --session-id 钉住会话 id、--resume 恢复
 codex = OpenAI Codex CLI (`codex`)：resume <uuid> 恢复；会话 id 需运行后捕获
+omp = Oh My Pi CLI (`omp`)：--resume <id 前缀> 恢复；会话 id 需运行后捕获
 """
 from __future__ import annotations
 
 from . import engine_settings
-from .config import CLAUDE_BIN, CODEX_BIN
+from .config import CLAUDE_BIN, CODEX_BIN, OMP_BIN
 
-ENGINES = {"cc", "codex"}
+ENGINES = {"cc", "codex", "omp"}
 
 # 收尾回报约定：光把 bosun-report skill 装上，模型收尾时未必想得起来调，
 # 尤其是以「反问用户」结尾的那一轮。这里在派发的 prompt 末尾显式要求一次。
@@ -42,6 +43,12 @@ def build_argv(engine: str, prompt: str, auto_approve: bool, session_uid: str | 
             argv.append("--dangerously-bypass-approvals-and-sandbox")
         argv.append(prompt)
         return argv
+    if engine == "omp":
+        argv = engine_settings.with_omp_runtime_args([OMP_BIN])
+        if auto_approve:
+            argv.append("--auto-approve")
+        argv.append(prompt)
+        return argv
     raise ValueError(f"unknown engine: {engine}")
 
 
@@ -60,6 +67,14 @@ def build_resume_argv(engine: str, session_uid: str, prompt: str, auto_approve: 
         argv = engine_settings.with_codex_runtime_args([CODEX_BIN, "resume", session_uid])
         if auto_approve:
             argv.append("--dangerously-bypass-approvals-and-sandbox")
+        if prompt:
+            argv.append(prompt)
+        return argv
+    if engine == "omp":
+        argv = engine_settings.with_omp_runtime_args([OMP_BIN])
+        if auto_approve:
+            argv.append("--auto-approve")
+        argv += ["--resume", session_uid]
         if prompt:
             argv.append(prompt)
         return argv
@@ -86,6 +101,15 @@ def build_headless_argv(engine: str, prompt: str, auto_approve: bool = True, jso
             argv.append("--dangerously-bypass-approvals-and-sandbox")
         argv.append(prompt)
         return argv
+    if engine == "omp":
+        argv = engine_settings.with_omp_runtime_args([OMP_BIN, "-p"])
+        if json_out:
+            # omp 的结构化输出是逐事件 NDJSON(--mode json)，不是单个 JSON 对象。
+            argv += ["--mode", "json"]
+        if auto_approve:
+            argv.append("--auto-approve")
+        argv.append(prompt)
+        return argv
     raise ValueError(f"unknown engine: {engine}")
 
 
@@ -96,4 +120,6 @@ def build_audit_argv(engine: str, audit_prompt: str) -> list[str]:
         return [*argv, audit_prompt]
     if engine == "codex":
         return engine_settings.with_codex_runtime_args([CODEX_BIN, "exec", audit_prompt])
+    if engine == "omp":
+        return engine_settings.with_omp_runtime_args([OMP_BIN, "-p", audit_prompt])
     raise ValueError(f"unknown engine: {engine}")

--- a/backend/app/reflection.py
+++ b/backend/app/reflection.py
@@ -159,7 +159,7 @@ def reflect(cwd: str, origin: str = "manual") -> int:
 
 _SETTING_KEYS = {"quota_block_pct", "mute_threshold", "max_concurrent"}
 _POLICY_FIELDS = {"scope", "scope_arg", "interval_minutes", "enabled"}
-_TASK_ENGINES = {"cc", "codex"}
+_TASK_ENGINES = {"cc", "codex", "omp"}
 
 # 值域护栏: 自进化路径与 UI 侧同一套下限, 防 LLM 提的畸形值绕过护栏设成危险配置。
 _SETTING_BOUNDS = {

--- a/backend/app/reflection.py
+++ b/backend/app/reflection.py
@@ -73,7 +73,7 @@ _PROMPT = """你是 Bosun（一个编排 Claude Code/Codex 的本地工具）的
 action 只能是以下白名单之一（拿不准就省略 action，表示纯建议）：
 - {{"type":"set_setting","key":"quota_block_pct|mute_threshold|max_concurrent","value":<整数>}}
 - {{"type":"set_policy","policy_id":<id>,"field":"scope|scope_arg|interval_minutes|enabled","value":<值>}}
-- {{"type":"create_task","project_id":<projects 中的 id>,"engine":"cc|codex","title":"..","prompt":"..","priority":1-10}}
+- {{"type":"create_task","project_id":<projects 中的 id>,"engine":"cc|codex|omp","title":"..","prompt":"..","priority":1-10}}
 
 需要改代码、修复项目问题或调查某个项目时，优先使用 create_task；采纳后只会创建 draft 任务，不会自动执行。
 只有安全的全局配置调整才使用 set_setting 或 set_policy。

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -18,7 +18,6 @@ class Settings(BaseModel):
     codex_effort: str = ""
     omp_model: str = ""
     omp_thinking: str = ""
-    omp_extra_args: str = ""
 
 
 @router.get("")
@@ -38,7 +37,6 @@ def get_settings():
         "omp_model_options": engine_settings.omp_model_options(),
         "omp_thinking": engine_settings.omp_thinking(),
         "omp_thinking_options": engine_settings.omp_thinking_options(),
-        "omp_extra_args": engine_settings.omp_extra_args(),
     }
 
 
@@ -71,12 +69,6 @@ def restart_backend(background_tasks: BackgroundTasks):
 
 @router.put("")
 def update_settings(body: Settings):
-    # 先校验：db.set_setting 是逐条立即提交的，校验放在后面会出现
-    # 「返回 400 但前面几项已经写进去了」的半保存状态。
-    try:
-        omp_extra_args = engine_settings.validate_omp_extra_args(body.omp_extra_args)
-    except engine_settings.OmpExtraArgsError as exc:
-        raise HTTPException(400, str(exc)) from exc
     db.set_setting("max_concurrent", max(1, body.max_concurrent))
     invocation = body.claude_invocation.strip().lower()
     if invocation not in engine_settings.CLAUDE_INVOCATIONS:
@@ -88,6 +80,5 @@ def update_settings(body: Settings):
     db.set_setting("codex_effort", engine_settings.normalize_codex_effort(body.codex_effort))
     db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
     db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
-    db.set_setting("omp_extra_args", omp_extra_args)
     scheduler.tick()  # 提高上限时立即拉起排队任务
     return get_settings()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -16,6 +16,8 @@ class Settings(BaseModel):
     claude_effort: str = ""
     codex_model: str = ""
     codex_effort: str = ""
+    omp_model: str = ""
+    omp_thinking: str = ""
 
 
 @router.get("")
@@ -31,6 +33,10 @@ def get_settings():
         "codex_model_options": engine_settings.codex_model_options(),
         "codex_effort": engine_settings.codex_effort(),
         "codex_effort_options": engine_settings.codex_effort_options(),
+        "omp_model": engine_settings.omp_model(),
+        "omp_model_options": engine_settings.omp_model_options(),
+        "omp_thinking": engine_settings.omp_thinking(),
+        "omp_thinking_options": engine_settings.omp_thinking_options(),
     }
 
 
@@ -39,6 +45,7 @@ def refresh_model_options(engine: str):
     binaries = {
         "cc": config.CLAUDE_BIN,
         "codex": config.CODEX_BIN,
+        "omp": config.OMP_BIN,
     }
     binary = binaries.get(engine)
     if not binary:
@@ -71,5 +78,7 @@ def update_settings(body: Settings):
     db.set_setting("claude_effort", engine_settings.normalize_claude_effort(body.claude_effort))
     db.set_setting("codex_model", engine_settings.normalize_codex_model(body.codex_model))
     db.set_setting("codex_effort", engine_settings.normalize_codex_effort(body.codex_effort))
+    db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
+    db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
     scheduler.tick()  # 提高上限时立即拉起排队任务
     return get_settings()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -82,6 +82,10 @@ def update_settings(body: Settings):
     db.set_setting("codex_effort", engine_settings.normalize_codex_effort(body.codex_effort))
     db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
     db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
-    db.set_setting("omp_extra_args", engine_settings.normalize_omp_extra_args(body.omp_extra_args))
+    try:
+        extra_args = engine_settings.validate_omp_extra_args(body.omp_extra_args)
+    except engine_settings.OmpExtraArgsError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    db.set_setting("omp_extra_args", extra_args)
     scheduler.tick()  # 提高上限时立即拉起排队任务
     return get_settings()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -18,6 +18,7 @@ class Settings(BaseModel):
     codex_effort: str = ""
     omp_model: str = ""
     omp_thinking: str = ""
+    omp_extra_args: str = ""
 
 
 @router.get("")
@@ -37,6 +38,7 @@ def get_settings():
         "omp_model_options": engine_settings.omp_model_options(),
         "omp_thinking": engine_settings.omp_thinking(),
         "omp_thinking_options": engine_settings.omp_thinking_options(),
+        "omp_extra_args": engine_settings.omp_extra_args(),
     }
 
 
@@ -80,5 +82,6 @@ def update_settings(body: Settings):
     db.set_setting("codex_effort", engine_settings.normalize_codex_effort(body.codex_effort))
     db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
     db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
+    db.set_setting("omp_extra_args", engine_settings.normalize_omp_extra_args(body.omp_extra_args))
     scheduler.tick()  # 提高上限时立即拉起排队任务
     return get_settings()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -71,6 +71,12 @@ def restart_backend(background_tasks: BackgroundTasks):
 
 @router.put("")
 def update_settings(body: Settings):
+    # 先校验：db.set_setting 是逐条立即提交的，校验放在后面会出现
+    # 「返回 400 但前面几项已经写进去了」的半保存状态。
+    try:
+        omp_extra_args = engine_settings.validate_omp_extra_args(body.omp_extra_args)
+    except engine_settings.OmpExtraArgsError as exc:
+        raise HTTPException(400, str(exc)) from exc
     db.set_setting("max_concurrent", max(1, body.max_concurrent))
     invocation = body.claude_invocation.strip().lower()
     if invocation not in engine_settings.CLAUDE_INVOCATIONS:
@@ -82,10 +88,6 @@ def update_settings(body: Settings):
     db.set_setting("codex_effort", engine_settings.normalize_codex_effort(body.codex_effort))
     db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
     db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
-    try:
-        extra_args = engine_settings.validate_omp_extra_args(body.omp_extra_args)
-    except engine_settings.OmpExtraArgsError as exc:
-        raise HTTPException(400, str(exc)) from exc
-    db.set_setting("omp_extra_args", extra_args)
+    db.set_setting("omp_extra_args", omp_extra_args)
     scheduler.tick()  # 提高上限时立即拉起排队任务
     return get_settings()

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -296,7 +296,7 @@ def handoff_task(task_id: int, body: HandoffBody):
     if t["status"] in ("queued", "running", "waiting_input"):
         scheduler.cancel(task_id)
     status = "queued" if body.start else "draft"
-    label = "CC" if body.engine == "cc" else "Codex"
+    label = {"cc": "CC", "codex": "Codex", "omp": "OMP"}.get(body.engine, body.engine.upper())
     base_title = (t["title"] or derive_title(origin)).strip()
     title = f"{base_title} · {label} 接力"[:80]
     new_id = db.execute(

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -186,23 +186,36 @@ def _capture_session(
     before: set,
     since: float,
 ) -> None:
-    """运行后轮询捕获引擎真实生成的会话 id(cc/codex/omp 都不支持事前钉 id)。"""
-    for _ in range(30):
-        time.sleep(1.5)
-        if engine == "cc":
-            uid = sessions.capture_cc_session(cwd, before, since)
-        elif engine == "omp":
-            # omp 的会话目录按 cwd 隔离，不会和别的项目串号
-            uid = sessions.capture_omp_session(cwd, before, since)
-        else:
-            with _session_capture_lock:
-                claimed = {
-                    row["session_uid"]
-                    for row in db.query(
-                        "SELECT session_uid FROM task WHERE id<>? AND session_uid IS NOT NULL",
-                        (task_id,),
-                    )
-                }
+    """运行后轮询捕获引擎真实生成的会话 id(cc/codex/omp 都不支持事前钉 id)。
+
+    引擎何时把 transcript 落盘并不受我们控制，首轮很慢时可能远超最初的 45s 快轮询窗口。
+    所以任务还活着就继续以更低频率轮询，任务结束后再补几次，避免会话永远认领不到——
+    那会连带让续跑、导出、历史和 token 结算全部失效。
+    """
+    fast_rounds = 30           # 前 45s 高频轮询，覆盖绝大多数情况
+    tail_rounds = 4            # 进程退出后再补几次，等最后的落盘
+    max_seconds = 2 * 60 * 60  # 兜底上限，防止任务挂死时线程常驻
+    started = time.monotonic()
+    rounds = 0
+    after_exit = 0
+    while True:
+        time.sleep(1.5 if rounds < fast_rounds else 5.0)
+        rounds += 1
+        # 认领要在锁内完成：同项目并发任务可能在任何文件落盘前都完成了 snapshot，
+        # 不排掉已被认领的 uid 就会两个任务共用同一个会话。
+        with _session_capture_lock:
+            claimed = {
+                row["session_uid"]
+                for row in db.query(
+                    "SELECT session_uid FROM task WHERE id<>? AND session_uid IS NOT NULL",
+                    (task_id,),
+                )
+            }
+            if engine == "cc":
+                uid = sessions.capture_cc_session(cwd, before, since, exclude_uids=claimed)
+            elif engine == "omp":
+                uid = sessions.capture_omp_session(cwd, before, since, exclude_uids=claimed)
+            else:
                 uid = sessions.capture_codex_session(
                     before,
                     since,
@@ -210,14 +223,27 @@ def _capture_session(
                     prompt=prompt,
                     exclude_uids=claimed,
                 )
+            changed = 0
+            if uid:
+                # 不再限定 status：进程已退出的任务同样需要补上会话 id，
+                # started_at 已能保证这是本次运行而不是历史轮次。
+                changed = db.execute_rowcount(
+                    "UPDATE task SET session_uid=? WHERE id=? AND started_at=? AND session_uid IS NULL",
+                    (uid, task_id, since),
+                )
         if uid:
-            changed = db.execute_rowcount(
-                "UPDATE task SET session_uid=? WHERE id=? AND started_at=? "
-                "AND status IN ('running','waiting_input') AND session_uid IS NULL",
-                (uid, task_id, since),
-            )
             if changed:
                 events.emit("task.session", {"task_id": task_id, "session_uid": uid})
+            return
+
+        row = db.query_one("SELECT status, session_uid FROM task WHERE id=?", (task_id,))
+        if row is None or row["session_uid"]:
+            return  # 任务已删除，或会话已由别的途径(如 SDK 回调)补上
+        if row["status"] not in ("running", "waiting_input"):
+            after_exit += 1
+            if after_exit >= tail_rounds:
+                return
+        if time.monotonic() - started > max_seconds:
             return
 
 

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -186,11 +186,14 @@ def _capture_session(
     before: set,
     since: float,
 ) -> None:
-    """运行后轮询捕获引擎真实生成的会话 id(cc/codex 都不支持事前钉 id)。"""
+    """运行后轮询捕获引擎真实生成的会话 id(cc/codex/omp 都不支持事前钉 id)。"""
     for _ in range(30):
         time.sleep(1.5)
         if engine == "cc":
             uid = sessions.capture_cc_session(cwd, before, since)
+        elif engine == "omp":
+            # omp 的会话目录按 cwd 隔离，不会和别的项目串号
+            uid = sessions.capture_omp_session(cwd, before, since)
         else:
             with _session_capture_lock:
                 claimed = {
@@ -282,7 +285,12 @@ def _start_task(row) -> None:
             argv = build_resume_argv(engine, session_uid, row["prompt"], auto)
         else:  # 首跑：引擎自建会话(会落盘)，运行后捕获真实 session id
             argv = build_argv(engine, row["prompt"], auto)
-            before = sessions.snapshot_cc(project["path"]) if engine == "cc" else sessions.snapshot_codex()
+            if engine == "cc":
+                before = sessions.snapshot_cc(project["path"])
+            elif engine == "omp":
+                before = sessions.snapshot_omp(project["path"])
+            else:
+                before = sessions.snapshot_codex()
             capture = (before, run_started_at)
         session = PtySession(
             task_id=row["id"],

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -234,6 +234,17 @@ def _capture_session(
         if uid:
             if changed:
                 events.emit("task.session", {"task_id": task_id, "session_uid": uid})
+                # 任务可能在会话落盘前就结束了：那一轮 _finalize_tokens 因为还没有
+                # session_uid 直接返回，用量会永远空着。认领晚于结算时补跑一次。
+                row = db.query_one(
+                    "SELECT status, tokens FROM task WHERE id=?", (task_id,)
+                )
+                if row and row["tokens"] is None and row["status"] not in (
+                    "running", "waiting_input",
+                ):
+                    threading.Thread(
+                        target=_finalize_tokens, args=(task_id, 0.5), daemon=True
+                    ).start()
             return
 
         row = db.query_one("SELECT status, session_uid FROM task WHERE id=?", (task_id,))

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -212,9 +212,9 @@ def _capture_session(
                 )
             }
             if engine == "cc":
-                uid = sessions.capture_cc_session(cwd, before, since, exclude_uids=claimed)
+                uid = sessions.capture_cc_session(cwd, before, since, exclude_uids=claimed, prompt=prompt)
             elif engine == "omp":
-                uid = sessions.capture_omp_session(cwd, before, since, exclude_uids=claimed)
+                uid = sessions.capture_omp_session(cwd, before, since, exclude_uids=claimed, prompt=prompt)
             else:
                 uid = sessions.capture_codex_session(
                     before,

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -44,16 +44,19 @@ def _capture_new_session(
     since_ts: float,
     uid_of: Callable[[Path], str | None],
     exclude_uids: set[str] | None = None,
+    engine: str | None = None,
+    prompt: str | None = None,
 ) -> str | None:
     """在按 cwd 隔离的会话目录里，取本次运行新出现的最新会话 uid。
 
-    cc 和 omp 都是「一个项目一个目录」，跨项目不会串号；但**同一项目并发跑两个任务**
-    时，两边都可能在任一文件落盘前完成 snapshot，于是同一个新文件被两个任务同时认领。
-    所以这里同样要排掉已被别的任务认领的 uid(exclude_uids)，由调用方在锁内取。
-
-    codex 的目录全局共享，还要额外核对 cwd 和首条 prompt，走 capture_codex_session。
+    cc 和 omp 都是「一个项目一个目录」，跨项目不会串号。但**同一项目并发跑两个任务**
+    时，两边都可能在任一文件落盘前完成 snapshot：
+    - 排掉已被别的任务认领的 uid(exclude_uids)防重复认领；
+    - 只排重还不够——两个任务仍可能各自认领对方的会话(互换)，所以给了 prompt 时
+      还要核对 transcript 的首条用户指令，和 capture_codex_session 同一套判据。
     """
     excluded = exclude_uids or set()
+    expected_prompt = _clean_prompt(prompt) if prompt is not None else None
     newest: tuple[float, str] | None = None
     for directory in directories:
         if not directory.is_dir():
@@ -70,6 +73,12 @@ def _capture_new_session(
                 continue
             if mtime < since_ts - 2:
                 continue
+            if expected_prompt is not None and engine is not None:
+                meta = _session_meta(p, engine)
+                # 首条指令还没落盘时 meta 为空/无 prompt：这轮先不认领，下轮再看，
+                # 不能凭 mtime 抢一个还不知道属于谁的会话。
+                if meta is None or meta.get("prompt") != expected_prompt:
+                    continue
             if newest is None or mtime > newest[0]:
                 newest = (mtime, uid)
     return newest[1] if newest else None
@@ -86,11 +95,16 @@ def _snapshot_dirs(directories: list[Path]) -> set[str]:
 
 
 def capture_cc_session(
-    cwd: str, before: set[str], since_ts: float, exclude_uids: set[str] | None = None
+    cwd: str,
+    before: set[str],
+    since_ts: float,
+    exclude_uids: set[str] | None = None,
+    prompt: str | None = None,
 ) -> str | None:
     """返回本次运行新生成的 cc 会话 uuid(项目目录里新出现的 <uuid>.jsonl)。"""
     return _capture_new_session(
-        [cc_project_dir(cwd)], before, since_ts, lambda p: p.stem, exclude_uids
+        [cc_project_dir(cwd)], before, since_ts, lambda p: p.stem, exclude_uids,
+        engine="cc", prompt=prompt,
     )
 
 
@@ -153,10 +167,17 @@ def snapshot_omp(cwd: str) -> set[str]:
 
 
 def capture_omp_session(
-    cwd: str, before: set[str], since_ts: float, exclude_uids: set[str] | None = None
+    cwd: str,
+    before: set[str],
+    since_ts: float,
+    exclude_uids: set[str] | None = None,
+    prompt: str | None = None,
 ) -> str | None:
     """返回本次运行新生成的 omp 会话 uuid。"""
-    return _capture_new_session(omp_project_dirs(cwd), before, since_ts, _omp_uid, exclude_uids)
+    return _capture_new_session(
+        omp_project_dirs(cwd), before, since_ts, _omp_uid, exclude_uids,
+        engine="omp", prompt=prompt,
+    )
 
 
 def _ts(value) -> float | None:

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -144,17 +144,24 @@ def omp_dir_digest(cwd: str) -> str:
 
 
 def omp_project_dirs(cwd: str) -> list[Path]:
-    """同一 cwd 下所有已存在的 omp 会话目录，按名字排序。
+    """同一 cwd 下所有可能存放会话的 omp 目录，按名字排序。
 
-    目录名是 `<scope>-<可读名>-<sha256(真实路径)>`，scope 由 omp 自己决定(实测 abs，
-    家目录/临时目录下可能是别的前缀)。哈希只认路径，所以同一项目理论上可能同时存在
-    多个前缀的桶——读取一律扫全部，避免「导入的会话看不见」或「新会话捕获不到」。
+    默认布局下目录名是 `<scope>-<可读名>-<sha256(真实路径)>`，scope 由 omp 自己决定
+    (实测 abs，家目录/临时目录下可能是别的前缀)。哈希只认路径，所以同一项目理论上
+    可能同时存在多个前缀的桶——读取一律扫全部，避免「导入的会话看不见」或
+    「新会话捕获不到」。
+
+    另外 PI_CODING_AGENT_SESSION_DIR 被设置时，omp 可能直接把会话文件写在该目录下
+    而不再分桶。两种语义都扫：文件名本身要过 _omp_uid 校验，多扫一个目录不会误认。
     """
-    digest = omp_dir_digest(cwd)
     root = omp_sessions_root()
     if not root.is_dir():
         return []
-    return sorted((p for p in root.glob(f"*-{digest}") if p.is_dir()), key=lambda p: p.name)
+    digest = omp_dir_digest(cwd)
+    dirs = sorted((p for p in root.glob(f"*-{digest}") if p.is_dir()), key=lambda p: p.name)
+    if any(_omp_uid(p) for p in root.glob("*.jsonl")):
+        dirs.append(root)
+    return dirs
 
 
 def omp_project_dir(cwd: str) -> Path:

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import time
 from collections.abc import Callable
@@ -16,7 +17,15 @@ from pathlib import Path
 
 CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
 CODEX_SESSIONS = Path.home() / ".codex" / "sessions"
+# omp 允许用 PI_CODING_AGENT_SESSION_DIR 改会话根目录；agent 是后端 spawn 的，
+# 继承的正是这份环境，所以这里读同一个变量才能跟它对上。
+_OMP_SESSIONS_ENV = "PI_CODING_AGENT_SESSION_DIR"
 OMP_SESSIONS = Path.home() / ".omp" / "agent" / "sessions"
+
+
+def omp_sessions_root() -> Path:
+    configured = os.environ.get(_OMP_SESSIONS_ENV)
+    return Path(configured).expanduser() if configured else OMP_SESSIONS
 
 _UUID_RE = re.compile(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
 
@@ -142,9 +151,10 @@ def omp_project_dirs(cwd: str) -> list[Path]:
     多个前缀的桶——读取一律扫全部，避免「导入的会话看不见」或「新会话捕获不到」。
     """
     digest = omp_dir_digest(cwd)
-    if not OMP_SESSIONS.is_dir():
+    root = omp_sessions_root()
+    if not root.is_dir():
         return []
-    return sorted((p for p in OMP_SESSIONS.glob(f"*-{digest}") if p.is_dir()), key=lambda p: p.name)
+    return sorted((p for p in root.glob(f"*-{digest}") if p.is_dir()), key=lambda p: p.name)
 
 
 def omp_project_dir(cwd: str) -> Path:
@@ -153,7 +163,7 @@ def omp_project_dir(cwd: str) -> Path:
     if existing:
         return existing[0]
     resolved = Path(cwd).expanduser().resolve()
-    return OMP_SESSIONS / f"abs-{resolved.name}-{omp_dir_digest(cwd)}"
+    return omp_sessions_root() / f"abs-{resolved.name}-{omp_dir_digest(cwd)}"
 
 
 def _omp_uid(path: Path) -> str | None:

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -73,16 +73,20 @@ def _capture_new_session(
                 continue
             if mtime < since_ts - 2:
                 continue
-            if expected_prompt is not None and engine is not None:
+            created = mtime
+            if engine is not None:
                 meta = _session_meta(p, engine)
-                # 首条指令还没落盘时 meta 为空/无 prompt：这轮先不认领，下轮再看，
-                # 不能凭 mtime 抢一个还不知道属于谁的会话。
-                if meta is None or meta.get("prompt") != expected_prompt:
-                    continue
-            # 并发任务的 prompt 可能完全相同(prompt 比对分不开)，此时取创建时间
-            # 最贴近本次启动的那个，而不是「最新的」——后者会让先起的任务抢到
-            # 后起任务的会话，两边互换。
-            distance = abs(mtime - since_ts)
+                if expected_prompt is not None:
+                    # 首条指令还没落盘时 meta 为空/无 prompt：这轮先不认领，下轮再看，
+                    # 不能抢一个还不知道属于谁的会话。
+                    if meta is None or meta.get("prompt") != expected_prompt:
+                        continue
+                if meta is not None and meta.get("created_at"):
+                    created = meta["created_at"]
+            # 并发任务的 prompt 可能完全相同(比对分不开)，此时按「创建时刻最贴近本次
+            # 启动」归属。必须用 transcript 自己记录的创建时间：mtime 会随会话继续
+            # 输出而后移，先起的任务反而会显得更贴近后起任务的启动时刻，导致互换。
+            distance = abs(created - since_ts)
             if best is None or distance < best[0]:
                 best = (distance, uid)
     return best[1] if best else None

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -57,7 +57,7 @@ def _capture_new_session(
     """
     excluded = exclude_uids or set()
     expected_prompt = _clean_prompt(prompt) if prompt is not None else None
-    newest: tuple[float, str] | None = None
+    best: tuple[float, str] | None = None  # (与启动时刻的距离, uid)
     for directory in directories:
         if not directory.is_dir():
             continue
@@ -79,9 +79,13 @@ def _capture_new_session(
                 # 不能凭 mtime 抢一个还不知道属于谁的会话。
                 if meta is None or meta.get("prompt") != expected_prompt:
                     continue
-            if newest is None or mtime > newest[0]:
-                newest = (mtime, uid)
-    return newest[1] if newest else None
+            # 并发任务的 prompt 可能完全相同(prompt 比对分不开)，此时取创建时间
+            # 最贴近本次启动的那个，而不是「最新的」——后者会让先起的任务抢到
+            # 后起任务的会话，两边互换。
+            distance = abs(mtime - since_ts)
+            if best is None or distance < best[0]:
+                best = (distance, uid)
+    return best[1] if best else None
 
 
 def _snapshot_dirs(directories: list[Path]) -> set[str]:

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -2,17 +2,21 @@
 
 cc:    ~/.claude/projects/<cwd 编码(/→-)>/<session-id>.jsonl
 codex: ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+omp:   ~/.omp/agent/sessions/abs-<目录名>-<sha256(真实路径)>/<时间戳>_<uuid>.jsonl
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
 CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
 CODEX_SESSIONS = Path.home() / ".codex" / "sessions"
+OMP_SESSIONS = Path.home() / ".omp" / "agent" / "sessions"
 
 _UUID_RE = re.compile(r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")
 
@@ -35,15 +39,26 @@ def snapshot_cc(cwd: str) -> set[str]:
     return {p.name for p in d.glob("*.jsonl")} if d.is_dir() else set()
 
 
-def capture_cc_session(cwd: str, before: set[str], since_ts: float) -> str | None:
-    """返回本次运行新生成的 cc 会话 uuid(项目目录里新出现的 <uuid>.jsonl)。"""
-    d = cc_project_dir(cwd)
-    if not d.is_dir():
+def _capture_new_session(
+    directory: Path,
+    before: set[str],
+    since_ts: float,
+    uid_of: Callable[[Path], str | None],
+) -> str | None:
+    """在按 cwd 隔离的会话目录里，取本次运行新出现的最新会话 uid。
+
+    cc 和 omp 都是「一个项目一个目录」，所以只比对新文件即可；codex 的目录全局共享，
+    需要额外核对 cwd 和首条 prompt，走 capture_codex_session。
+    """
+    if not directory.is_dir():
         return None
     newest: tuple[float, str] | None = None
-    for p in d.glob("*.jsonl"):
+    for p in directory.glob("*.jsonl"):
         if p.name in before:
             continue  # 只认新文件，排除已存在(如其它会话)
+        uid = uid_of(p)
+        if uid is None:
+            continue
         try:
             mtime = p.stat().st_mtime
         except OSError:
@@ -51,8 +66,13 @@ def capture_cc_session(cwd: str, before: set[str], since_ts: float) -> str | Non
         if mtime < since_ts - 2:
             continue
         if newest is None or mtime > newest[0]:
-            newest = (mtime, p.stem)
+            newest = (mtime, uid)
     return newest[1] if newest else None
+
+
+def capture_cc_session(cwd: str, before: set[str], since_ts: float) -> str | None:
+    """返回本次运行新生成的 cc 会话 uuid(项目目录里新出现的 <uuid>.jsonl)。"""
+    return _capture_new_session(cc_project_dir(cwd), before, since_ts, lambda p: p.stem)
 
 
 def _codex_rollouts() -> list[Path]:
@@ -68,9 +88,47 @@ def codex_session_path(uid: str) -> Path | None:
     return None
 
 
+def omp_dir_digest(cwd: str) -> str:
+    """omp 会话目录名里的哈希：sha256(解析后的真实路径)。"""
+    return hashlib.sha256(str(Path(cwd).expanduser().resolve()).encode()).hexdigest()
+
+
+def omp_project_dir(cwd: str) -> Path:
+    """omp 按 cwd 分目录存会话。目录名前缀是 scope(实测为 abs)，按哈希后缀匹配更稳。"""
+    resolved = Path(cwd).expanduser().resolve()
+    digest = hashlib.sha256(str(resolved).encode()).hexdigest()
+    if OMP_SESSIONS.is_dir():
+        for path in OMP_SESSIONS.glob(f"*-{digest}"):
+            if path.is_dir():
+                return path
+    return OMP_SESSIONS / f"abs-{resolved.name}-{digest}"
+
+
+def _omp_uid(path: Path) -> str | None:
+    """omp 会话文件名形如 <时间戳>_<uuid>.jsonl。"""
+    uid = path.stem.rsplit("_", 1)[-1]
+    return uid if _UUID_RE.fullmatch(uid) else None
+
+
+def omp_session_path(cwd: str, uid: str) -> Path | None:
+    return next(iter(sorted(omp_project_dir(cwd).glob(f"*_{uid}.jsonl"))), None)
+
+
+def snapshot_omp(cwd: str) -> set[str]:
+    d = omp_project_dir(cwd)
+    return {p.name for p in d.glob("*.jsonl")} if d.is_dir() else set()
+
+
+def capture_omp_session(cwd: str, before: set[str], since_ts: float) -> str | None:
+    """返回本次运行新生成的 omp 会话 uuid。"""
+    return _capture_new_session(omp_project_dir(cwd), before, since_ts, _omp_uid)
+
+
 def _ts(value) -> float | None:
     if isinstance(value, (int, float)):
-        return float(value)
+        # omp 的消息时间戳是毫秒 epoch；cc/codex 是秒。1e11 秒 ≈ 公元 5138 年，
+        # 超过就只可能是毫秒。
+        return float(value) / 1000.0 if value > 1e11 else float(value)
     if not isinstance(value, str) or not value:
         return None
     try:
@@ -151,6 +209,8 @@ def _session_meta(path: Path, engine: str, project_path: str | None = None) -> d
         if not m:
             return None
         uid = m.group(1)
+    elif engine == "omp":
+        uid = _omp_uid(path)
     if not uid or not _UUID_RE.fullmatch(uid):
         return None
 
@@ -230,11 +290,16 @@ def local_session_info(engine: str, cwd: str, uid: str) -> dict | None:
         if path is None or not path.exists():
             return None
         return _session_meta(path, engine, cwd)
+    if engine == "omp":
+        path = omp_session_path(cwd, uid)
+        if path is None or not path.exists():
+            return None
+        return _session_meta(path, engine, cwd)
     return None
 
 
 def discover_local_sessions(cwd: str, limit: int = 50) -> list[dict]:
-    """Discover resumable local cc/codex transcript files for a project path."""
+    """Discover resumable local cc/codex/omp transcript files for a project path."""
     limit = max(1, min(int(limit or 50), 200))
     found: list[dict] = []
 
@@ -257,6 +322,13 @@ def discover_local_sessions(cwd: str, limit: int = 50) -> list[dict]:
             found.append(meta)
             if len(found) >= limit * 2:
                 break
+
+    omp_dir = omp_project_dir(cwd)
+    if omp_dir.is_dir():
+        for path in sorted(omp_dir.glob("*.jsonl"), key=_mtime, reverse=True)[:limit]:
+            meta = _session_meta(path, "omp", cwd)
+            if meta:
+                found.append(meta)
 
     found.sort(key=lambda item: item.get("updated_at") or 0, reverse=True)
     return found[:limit]
@@ -311,12 +383,17 @@ def capture_codex_session(
     return newest[1] if newest else None
 
 
+def _session_path(engine: str, cwd: str, uid: str) -> Path | None:
+    if engine == "cc":
+        return cc_session_path(cwd, uid)
+    if engine == "omp":
+        return omp_session_path(cwd, uid)
+    return codex_session_path(uid)
+
+
 # ---- 分享：读/写会话文件 ----
 def read_session(engine: str, cwd: str, uid: str) -> str | None:
-    if engine == "cc":
-        p = cc_session_path(cwd, uid)
-    else:
-        p = codex_session_path(uid)
+    p = _session_path(engine, cwd, uid)
     if p is None or not p.exists():
         return None
     try:
@@ -360,10 +437,7 @@ def session_history(
     Codex exit. The engine JSONL is the durable source for readable conversation
     history and also exists before a queued resume task starts a new PTY.
     """
-    if engine == "cc":
-        path = cc_session_path(cwd, uid)
-    else:
-        path = codex_session_path(uid)
+    path = _session_path(engine, cwd, uid)
     if path is None or not path.exists():
         return {"messages": [], "truncated": False}
 
@@ -399,6 +473,16 @@ def session_history(
                     append(msg.get("role") or obj.get("type"), _history_content_text(msg.get("content")), timestamp)
                     continue
 
+                if engine == "omp":
+                    # omp: {"type":"message","message":{"role":...,"content":[...]}}
+                    if obj.get("type") != "message":
+                        continue
+                    msg = obj.get("message")
+                    if not isinstance(msg, dict):
+                        continue
+                    append(msg.get("role"), _history_content_text(msg.get("content")), timestamp)
+                    continue
+
                 payload = obj.get("payload")
                 if not isinstance(payload, dict):
                     continue
@@ -425,21 +509,16 @@ def session_history(
 
 
 def _usage_tokens(usage: dict) -> int | None:
-    total = 0
-    found = False
-    for k in ("input_tokens", "output_tokens"):
+    """input+output 口径。cc/codex 的键是 *_tokens，omp 用的是 input/output。"""
+    for keys in (("input_tokens", "output_tokens"), ("input", "output")):
+        parts = [usage[k] for k in keys if isinstance(usage.get(k), int)]
+        if parts:
+            return sum(parts)
+    for k in ("total_tokens", "totalTokens"):
         v = usage.get(k)
         if isinstance(v, int):
-            total += v
-            found = True
-    if found:
-        return total
-    v = usage.get("total_tokens")
-    return v if isinstance(v, int) else None
-
-
-def _session_path(engine: str, cwd: str, uid: str) -> Path | None:
-    return cc_session_path(cwd, uid) if engine == "cc" else codex_session_path(uid)
+            return v
+    return None
 
 
 class LiveTokenCounter:
@@ -550,11 +629,12 @@ def count_tokens(
     since: float | None = None,
     until: float | None = None,
 ) -> int | None:
-    """从会话 transcript 汇总 token 用量(input+output)。会话未落盘则返回 None。"""
-    if engine == "cc":
-        p = cc_session_path(cwd, uid)
-    else:
-        p = codex_session_path(uid)
+    """从会话 transcript 汇总 token 用量(input+output)。会话未落盘则返回 None。
+
+    cc / omp 的 usage 是逐条消息的增量，直接累加；codex 的 token_count 是累计值，
+    走下面的窗口差值分支。
+    """
+    p = _session_path(engine, cwd, uid)
     if p is None or not p.exists():
         return None
 
@@ -637,6 +717,10 @@ def write_session(engine: str, cwd: str, uid: str, content: str) -> Path:
         raise ValueError(f"非法 session_uid: {uid!r}")
     if engine == "cc":
         p = cc_session_path(cwd, uid)
+    elif engine == "omp":
+        # omp 按 cwd 分目录，文件名 <时间戳>_<uuid> 供 --resume 按 id 前缀检索
+        ts = time.strftime("%Y-%m-%dT%H-%M-%S-000Z")
+        p = omp_project_dir(cwd) / f"{ts}_{uid}.jsonl"
     else:
         # 放到今天的日期目录，文件名带上 uuid 供 codex 按 id 检索
         day = time.strftime("%Y/%m/%d")

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -35,44 +35,63 @@ def cc_session_path(cwd: str, uid: str) -> Path:
 
 
 def snapshot_cc(cwd: str) -> set[str]:
-    d = cc_project_dir(cwd)
-    return {p.name for p in d.glob("*.jsonl")} if d.is_dir() else set()
+    return _snapshot_dirs([cc_project_dir(cwd)])
 
 
 def _capture_new_session(
-    directory: Path,
+    directories: list[Path],
     before: set[str],
     since_ts: float,
     uid_of: Callable[[Path], str | None],
+    exclude_uids: set[str] | None = None,
 ) -> str | None:
     """在按 cwd 隔离的会话目录里，取本次运行新出现的最新会话 uid。
 
-    cc 和 omp 都是「一个项目一个目录」，所以只比对新文件即可；codex 的目录全局共享，
-    需要额外核对 cwd 和首条 prompt，走 capture_codex_session。
+    cc 和 omp 都是「一个项目一个目录」，跨项目不会串号；但**同一项目并发跑两个任务**
+    时，两边都可能在任一文件落盘前完成 snapshot，于是同一个新文件被两个任务同时认领。
+    所以这里同样要排掉已被别的任务认领的 uid(exclude_uids)，由调用方在锁内取。
+
+    codex 的目录全局共享，还要额外核对 cwd 和首条 prompt，走 capture_codex_session。
     """
-    if not directory.is_dir():
-        return None
+    excluded = exclude_uids or set()
     newest: tuple[float, str] | None = None
-    for p in directory.glob("*.jsonl"):
-        if p.name in before:
-            continue  # 只认新文件，排除已存在(如其它会话)
-        uid = uid_of(p)
-        if uid is None:
+    for directory in directories:
+        if not directory.is_dir():
             continue
-        try:
-            mtime = p.stat().st_mtime
-        except OSError:
-            continue
-        if mtime < since_ts - 2:
-            continue
-        if newest is None or mtime > newest[0]:
-            newest = (mtime, uid)
+        for p in directory.glob("*.jsonl"):
+            if str(p) in before:
+                continue  # 只认新文件，排除已存在(如其它会话)
+            uid = uid_of(p)
+            if uid is None or uid in excluded:
+                continue
+            try:
+                mtime = p.stat().st_mtime
+            except OSError:
+                continue
+            if mtime < since_ts - 2:
+                continue
+            if newest is None or mtime > newest[0]:
+                newest = (mtime, uid)
     return newest[1] if newest else None
 
 
-def capture_cc_session(cwd: str, before: set[str], since_ts: float) -> str | None:
+def _snapshot_dirs(directories: list[Path]) -> set[str]:
+    """快照现存会话文件的绝对路径，用于事后比对出本次新建的那个。"""
+    return {
+        str(p)
+        for directory in directories
+        if directory.is_dir()
+        for p in directory.glob("*.jsonl")
+    }
+
+
+def capture_cc_session(
+    cwd: str, before: set[str], since_ts: float, exclude_uids: set[str] | None = None
+) -> str | None:
     """返回本次运行新生成的 cc 会话 uuid(项目目录里新出现的 <uuid>.jsonl)。"""
-    return _capture_new_session(cc_project_dir(cwd), before, since_ts, lambda p: p.stem)
+    return _capture_new_session(
+        [cc_project_dir(cwd)], before, since_ts, lambda p: p.stem, exclude_uids
+    )
 
 
 def _codex_rollouts() -> list[Path]:
@@ -93,15 +112,26 @@ def omp_dir_digest(cwd: str) -> str:
     return hashlib.sha256(str(Path(cwd).expanduser().resolve()).encode()).hexdigest()
 
 
+def omp_project_dirs(cwd: str) -> list[Path]:
+    """同一 cwd 下所有已存在的 omp 会话目录，按名字排序。
+
+    目录名是 `<scope>-<可读名>-<sha256(真实路径)>`，scope 由 omp 自己决定(实测 abs，
+    家目录/临时目录下可能是别的前缀)。哈希只认路径，所以同一项目理论上可能同时存在
+    多个前缀的桶——读取一律扫全部，避免「导入的会话看不见」或「新会话捕获不到」。
+    """
+    digest = omp_dir_digest(cwd)
+    if not OMP_SESSIONS.is_dir():
+        return []
+    return sorted((p for p in OMP_SESSIONS.glob(f"*-{digest}") if p.is_dir()), key=lambda p: p.name)
+
+
 def omp_project_dir(cwd: str) -> Path:
-    """omp 按 cwd 分目录存会话。目录名前缀是 scope(实测为 abs)，按哈希后缀匹配更稳。"""
+    """写入用的单一目标目录：优先复用 omp 已建好的桶，没有才按 abs 约定新建。"""
+    existing = omp_project_dirs(cwd)
+    if existing:
+        return existing[0]
     resolved = Path(cwd).expanduser().resolve()
-    digest = hashlib.sha256(str(resolved).encode()).hexdigest()
-    if OMP_SESSIONS.is_dir():
-        for path in OMP_SESSIONS.glob(f"*-{digest}"):
-            if path.is_dir():
-                return path
-    return OMP_SESSIONS / f"abs-{resolved.name}-{digest}"
+    return OMP_SESSIONS / f"abs-{resolved.name}-{omp_dir_digest(cwd)}"
 
 
 def _omp_uid(path: Path) -> str | None:
@@ -111,17 +141,22 @@ def _omp_uid(path: Path) -> str | None:
 
 
 def omp_session_path(cwd: str, uid: str) -> Path | None:
-    return next(iter(sorted(omp_project_dir(cwd).glob(f"*_{uid}.jsonl"))), None)
+    for d in omp_project_dirs(cwd):
+        found = next(iter(sorted(d.glob(f"*_{uid}.jsonl"))), None)
+        if found is not None:
+            return found
+    return None
 
 
 def snapshot_omp(cwd: str) -> set[str]:
-    d = omp_project_dir(cwd)
-    return {p.name for p in d.glob("*.jsonl")} if d.is_dir() else set()
+    return _snapshot_dirs(omp_project_dirs(cwd))
 
 
-def capture_omp_session(cwd: str, before: set[str], since_ts: float) -> str | None:
+def capture_omp_session(
+    cwd: str, before: set[str], since_ts: float, exclude_uids: set[str] | None = None
+) -> str | None:
     """返回本次运行新生成的 omp 会话 uuid。"""
-    return _capture_new_session(omp_project_dir(cwd), before, since_ts, _omp_uid)
+    return _capture_new_session(omp_project_dirs(cwd), before, since_ts, _omp_uid, exclude_uids)
 
 
 def _ts(value) -> float | None:
@@ -323,12 +358,11 @@ def discover_local_sessions(cwd: str, limit: int = 50) -> list[dict]:
             if len(found) >= limit * 2:
                 break
 
-    omp_dir = omp_project_dir(cwd)
-    if omp_dir.is_dir():
-        for path in sorted(omp_dir.glob("*.jsonl"), key=_mtime, reverse=True)[:limit]:
-            meta = _session_meta(path, "omp", cwd)
-            if meta:
-                found.append(meta)
+    omp_files = [p for d in omp_project_dirs(cwd) for p in d.glob("*.jsonl")]
+    for path in sorted(omp_files, key=_mtime, reverse=True)[:limit]:
+        meta = _session_meta(path, "omp", cwd)
+        if meta:
+            found.append(meta)
 
     found.sort(key=lambda item: item.get("updated_at") or 0, reverse=True)
     return found[:limit]
@@ -710,6 +744,28 @@ def count_tokens(
     return total if found else None
 
 
+def _reroot_omp_content(content: str, cwd: str) -> str:
+    """把导入会话头部记录的 cwd 改写成目标项目路径。
+
+    omp 的会话头带着原始 cwd。原样落到目标项目的目录里，头里却指向源仓库，
+    resume 时可能切回源仓库继续改代码(或卡在 omp 的重定位询问上)。
+    """
+    target = str(Path(cwd).expanduser().resolve())
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and obj.get("type") == "session" and "cwd" in obj:
+            obj["cwd"] = target
+            lines[i] = json.dumps(obj, ensure_ascii=False)
+            break
+    return "\n".join(lines) + "\n"
+
+
 def write_session(engine: str, cwd: str, uid: str, content: str) -> Path:
     """把分享来的会话写入本机对应位置，供 resume 加载。"""
     # 安全: uid 必须是合法 UUID，防止路径穿越(如 ../../.zshenv)写任意文件
@@ -721,6 +777,7 @@ def write_session(engine: str, cwd: str, uid: str, content: str) -> Path:
         # omp 按 cwd 分目录，文件名 <时间戳>_<uuid> 供 --resume 按 id 前缀检索
         ts = time.strftime("%Y-%m-%dT%H-%M-%S-000Z")
         p = omp_project_dir(cwd) / f"{ts}_{uid}.jsonl"
+        content = _reroot_omp_content(content, cwd)
     else:
         # 放到今天的日期目录，文件名带上 uuid 供 codex 按 id 检索
         day = time.strftime("%Y/%m/%d")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   omp_model_options: [{ value: "", label: "默认" }],
   omp_thinking: "",
   omp_thinking_options: [{ value: "", label: "默认" }],
+  omp_extra_args: "",
 };
 const PULL_REFRESH_TRIGGER_PX = 72;
 const PULL_REFRESH_MAX_PX = 96;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,6 @@ const DEFAULT_SETTINGS: AppSettings = {
   omp_model_options: [{ value: "", label: "默认" }],
   omp_thinking: "",
   omp_thinking_options: [{ value: "", label: "默认" }],
-  omp_extra_args: "",
 };
 const PULL_REFRESH_TRIGGER_PX = 72;
 const PULL_REFRESH_MAX_PX = 96;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ import { QuotaBadge } from "./components/QuotaBadge";
 import { SettingsView } from "./components/SettingsView";
 import { OverlayHost, confirmDialog, toast } from "./overlay";
 import { guardQuota } from "./quota";
-import type { Project } from "./types";
+import type { Engine, Project } from "./types";
 import { useSingleFlight } from "./useSingleFlight";
 
 type Tab = "projects" | "tasks" | "claude" | "stats" | "delivery" | "settings";
@@ -41,6 +41,10 @@ const DEFAULT_SETTINGS: AppSettings = {
   codex_model_options: [{ value: "", label: "默认" }],
   codex_effort: "",
   codex_effort_options: [{ value: "", label: "默认" }],
+  omp_model: "",
+  omp_model_options: [{ value: "", label: "默认" }],
+  omp_thinking: "",
+  omp_thinking_options: [{ value: "", label: "默认" }],
 };
 const PULL_REFRESH_TRIGGER_PX = 72;
 const PULL_REFRESH_MAX_PX = 96;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import { authHeaders, setToken } from "./auth";
-import type { Finding, IssueSource, LocalSession, Project, ReplySuggestion, Task } from "./types";
+import type { Engine, Finding, IssueSource, LocalSession, Project, ReplySuggestion, Task } from "./types";
 
 export type AppSettings = {
   max_concurrent: number;
@@ -12,6 +12,10 @@ export type AppSettings = {
   codex_model_options: { value: string; label: string }[];
   codex_effort: string;
   codex_effort_options: { value: string; label: string }[];
+  omp_model: string;
+  omp_model_options: { value: string; label: string }[];
+  omp_thinking: string;
+  omp_thinking_options: { value: string; label: string }[];
 };
 
 export type ClaudeResourceCategory =
@@ -101,7 +105,7 @@ export type ProposalTaskSummary = {
   project_id: number;
   title: string | null;
   status: string;
-  engine: "cc" | "codex";
+  engine: Engine;
 };
 
 export type ProposalAction = {
@@ -197,7 +201,7 @@ export const api = {
   tasks: (projectId?: number) =>
     fetch(projectId == null ? "/api/tasks" : `/api/tasks?project_id=${projectId}`).then((r) => j<Task[]>(r)),
   getTask: (id: number) => fetch(`/api/tasks/${id}`).then((r) => j<Task>(r)),
-  updateTask: (id: number, body: { title?: string; prompt?: string; engine?: "cc" | "codex" }) =>
+  updateTask: (id: number, body: { title?: string; prompt?: string; engine?: Engine }) =>
     write<Task>("PUT", `/api/tasks/${id}`, body),
   getLog: (id: number, source: "auto" | "terminal" | "script" = "auto") =>
     fetch(`/api/tasks/${id}/log?source=${source}`).then((r) =>
@@ -248,8 +252,8 @@ export const api = {
     write<{ id: number }>("POST", `/api/tasks/${id}/rerun`),
   continueTask: (id: number, body: { prompt?: string; compact?: boolean; start?: boolean }) =>
     write<{ id: number }>("POST", `/api/tasks/${id}/continue`, body),
-  handoffTask: (id: number, engine: "cc" | "codex", start = true) =>
-    write<{ id: number; engine: "cc" | "codex"; from_task_id: number }>(
+  handoffTask: (id: number, engine: Engine, start = true) =>
+    write<{ id: number; engine: Engine; from_task_id: number }>(
       "POST", `/api/tasks/${id}/handoff`, { engine, start },
     ),
   exportSession: (id: number) =>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,6 +16,7 @@ export type AppSettings = {
   omp_model_options: { value: string; label: string }[];
   omp_thinking: string;
   omp_thinking_options: { value: string; label: string }[];
+  omp_extra_args: string;
 };
 
 export type ClaudeResourceCategory =

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -16,7 +16,6 @@ export type AppSettings = {
   omp_model_options: { value: string; label: string }[];
   omp_thinking: string;
   omp_thinking_options: { value: string; label: string }[];
-  omp_extra_args: string;
 };
 
 export type ClaudeResourceCategory =

--- a/frontend/src/components/ActiveTasksView.tsx
+++ b/frontend/src/components/ActiveTasksView.tsx
@@ -19,6 +19,7 @@ import { CreateTaskDialog } from "./CreateTaskDialog";
 import { TerminalPanel } from "./TerminalPanel";
 import { TerminalWorkspace, type WorkspaceLayout } from "./TerminalWorkspace";
 import { taskPromptText } from "../taskText";
+import { engineBadgeClass, engineName, engineShort } from "../engines";
 
 const ACTIVE_STATUSES = new Set(["queued", "running", "waiting_input"]);
 const ARCHIVED_STATUSES = new Set(["done", "failed", "cancelled", "interrupted"]);
@@ -36,15 +37,12 @@ function attentionLabel(t: Task): string {
 }
 
 function EngineBadge({ engine }: { engine: Task["engine"] }) {
-  const isCc = engine === "cc";
   return (
     <span
-      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
-        isCc ? "bg-violet-50 text-violet-600" : "bg-emerald-50 text-emerald-600"
-      }`}
-      title={isCc ? "Claude Code" : "Codex"}
+      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${engineBadgeClass(engine)}`}
+      title={engineName(engine)}
     >
-      {isCc ? "CC" : "Codex"}
+      {engineShort(engine)}
     </span>
   );
 }

--- a/frontend/src/components/AutopilotDialog.tsx
+++ b/frontend/src/components/AutopilotDialog.tsx
@@ -139,6 +139,7 @@ export function AutopilotDialog({ project, onClose }: { project: Project; onClos
               >
                 <option value="cc">Claude Code</option>
                 <option value="codex">Codex</option>
+                <option value="omp">Oh My Pi</option>
               </select>
             </label>
             <label className="flex flex-col gap-1">
@@ -150,6 +151,7 @@ export function AutopilotDialog({ project, onClose }: { project: Project; onClos
               >
                 <option value="codex">Codex</option>
                 <option value="cc">Claude Code</option>
+                <option value="omp">Oh My Pi</option>
               </select>
             </label>
             <label className="flex flex-col gap-1">

--- a/frontend/src/components/CreateTaskDialog.tsx
+++ b/frontend/src/components/CreateTaskDialog.tsx
@@ -6,6 +6,7 @@ import type { Engine, Project } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
 import { AttachmentPicker } from "./AttachmentPicker";
 import { Modal } from "./Modal";
+import { engineName } from "../engines";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -175,7 +176,7 @@ export function CreateTaskDialog({
         }
       }
 
-      if (r.auto_reason) toast(`🤖 自动选了 ${r.engine === "cc" ? "Claude" : "Codex"}：${r.auto_reason}`, "info");
+      if (r.auto_reason) toast(`🤖 自动选了 ${engineName(r.engine)}：${r.auto_reason}`, "info");
       onCreated();
       onClose();
 

--- a/frontend/src/components/CreateTaskDialog.tsx
+++ b/frontend/src/components/CreateTaskDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type ClipboardEvent as ReactClipboardEvent
 import { api } from "../api";
 import { toast } from "../overlay";
 import { guardQuota } from "../quota";
-import type { Project } from "../types";
+import type { Engine, Project } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
 import { AttachmentPicker } from "./AttachmentPicker";
 import { Modal } from "./Modal";
@@ -19,7 +19,7 @@ type PendingAttachment = {
 
 type RememberedTaskSettings = {
   projectId?: number;
-  engine?: "auto" | "cc" | "codex";
+  engine?: "auto" | Engine;
   priority?: number;
   autoApprove?: boolean;
 };
@@ -75,8 +75,8 @@ export function CreateTaskDialog({
   );
   const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
   const selectedProject = availableProjects.find((item) => item.id === selectedProjectId);
-  const [engine, setEngine] = useState<"auto" | "cc" | "codex">(
-    ["auto", "cc", "codex"].includes(initialSettings.engine ?? "")
+  const [engine, setEngine] = useState<"auto" | Engine>(
+    ["auto", "cc", "codex", "omp"].includes(initialSettings.engine ?? "")
       ? initialSettings.engine!
       : "auto",
   );
@@ -234,10 +234,14 @@ export function CreateTaskDialog({
             <input type="radio" checked={engine === "codex"} onChange={() => setEngine("codex")} />
             Codex
           </label>
+          <label className="flex items-center gap-1.5">
+            <input type="radio" checked={engine === "omp"} onChange={() => setEngine("omp")} />
+            Oh My Pi
+          </label>
         </div>
         <textarea
           className="h-32 w-full rounded-lg border border-slate-200 bg-slate-50 p-2.5 font-mono text-xs text-slate-800 focus:border-teal-500 focus:outline-none"
-          placeholder="给 cc/codex 的指令…"
+          placeholder="给 cc/codex/omp 的指令…"
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           autoFocus={!projects}
@@ -311,7 +315,7 @@ export function CreateTaskDialog({
             className={`flex items-center gap-2 rounded-lg border px-2.5 py-1.5 text-sm ${
               autoApprove ? "border-amber-300 bg-amber-50 text-amber-700" : "border-slate-200 text-slate-600"
             }`}
-            title="cc: --dangerously-skip-permissions / codex: --dangerously-bypass-approvals-and-sandbox"
+            title="cc: --dangerously-skip-permissions / codex: --dangerously-bypass-approvals-and-sandbox / omp: --auto-approve"
           >
             <input
               type="checkbox"

--- a/frontend/src/components/ImportSessionDialog.tsx
+++ b/frontend/src/components/ImportSessionDialog.tsx
@@ -3,6 +3,7 @@ import { api } from "../api";
 import type { LocalSession, Project } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
 import { Modal } from "./Modal";
+import { engineName } from "../engines";
 
 function fmtTime(ts: number | null | undefined): string {
   if (!ts) return "时间未知";
@@ -12,10 +13,6 @@ function fmtTime(ts: number | null | undefined): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function engineLabel(engine: string): string {
-  return engine === "cc" ? "Claude" : "Codex";
 }
 
 export function ImportSessionDialog({
@@ -111,7 +108,7 @@ export function ImportSessionDialog({
                       {s.title}
                     </div>
                     <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-1 text-[11px] text-slate-400">
-                      <span>{engineLabel(s.engine)}</span>
+                      <span>{engineName(s.engine)}</span>
                       <span className="font-mono">{s.session_uid.slice(0, 8)}</span>
                       <span>{fmtTime(s.updated_at)}</span>
                       <span>{s.turns} 轮</span>

--- a/frontend/src/components/QuotaBadge.tsx
+++ b/frontend/src/components/QuotaBadge.tsx
@@ -6,6 +6,7 @@ import {
   type EngineToolUpdateResult,
   type HostMetrics,
 } from "../api";
+import type { Engine } from "../types";
 import { Modal } from "./Modal";
 
 type ProviderUsage = {
@@ -374,6 +375,7 @@ function ProviderDetail({
   label,
   note,
   q,
+  quotaUnsupported = false,
   engine,
   tool,
   toolState,
@@ -384,6 +386,8 @@ function ProviderDetail({
   label: string;
   note: string;
   q: ProviderUsage | null | undefined;
+  /** 该引擎没有订阅额度接口(如 omp 自带 provider key)，只展示版本与更新。 */
+  quotaUnsupported?: boolean;
   engine: string;
   tool: EngineToolInfo | null | undefined;
   toolState: EngineToolState | undefined;
@@ -401,7 +405,7 @@ function ProviderDetail({
           <div className="text-[11px] text-slate-400">{note}</div>
         </div>
         <span className={`rounded-full px-2 py-0.5 text-[11px] ${q?.available ? "bg-emerald-50 text-emerald-600" : "bg-slate-100 text-slate-500"}`}>
-          {!q ? "读取中" : q.available ? "可用" : "不可用"}
+          {quotaUnsupported ? "无额度接口" : !q ? "读取中" : q.available ? "可用" : "不可用"}
         </span>
       </div>
       {q?.available ? (
@@ -416,7 +420,9 @@ function ProviderDetail({
         </div>
       ) : (
         <div className="rounded-md bg-slate-50 px-2 py-1.5 text-xs text-slate-500">
-          {q?.error || "正在读取状态"}
+          {quotaUnsupported
+            ? "自带 provider 凭据，没有订阅额度接口，不参与额度阈值拦截"
+            : q?.error || "正在读取状态"}
         </div>
       )}
       <ToolVersionPanel
@@ -461,14 +467,14 @@ export function QuotaBadge({
   }, [setToolState]);
 
   const loadTools = useCallback(async () => {
-    for (const engine of ["cc", "codex"]) setToolState(engine, { loading: true, error: null, result: null });
+    for (const engine of ["cc", "codex", "omp"]) setToolState(engine, { loading: true, error: null, result: null });
     try {
       const info = await api.engineTools.list();
       setTools(info);
-      for (const engine of ["cc", "codex"]) setToolState(engine, { loading: false });
+      for (const engine of ["cc", "codex", "omp"]) setToolState(engine, { loading: false });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      for (const engine of ["cc", "codex"]) setToolState(engine, { loading: false, error: message });
+      for (const engine of ["cc", "codex", "omp"]) setToolState(engine, { loading: false, error: message });
     }
   }, [setToolState]);
 
@@ -526,7 +532,7 @@ export function QuotaBadge({
         type="button"
         className="flex min-w-0 flex-1 items-center justify-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-2.5 py-1.5 text-xs hover:bg-emerald-100 md:hidden"
         onClick={() => setOpen(true)}
-        title="查看 cc / codex 状态详情"
+        title="查看 cc / codex / omp 状态详情"
       >
         <CompactProvider label="cc" q={q?.claude} />
         <span className="shrink-0 text-emerald-200">|</span>
@@ -536,7 +542,7 @@ export function QuotaBadge({
         type="button"
         className="hidden max-w-full items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs hover:bg-emerald-100 md:flex"
         onClick={() => setOpen(true)}
-        title={`查看 cc / codex 状态详情；${hostTitle(host)}`}
+        title={`查看 cc / codex / omp 状态详情；${hostTitle(host)}`}
       >
         <Provider label="Claude" q={q?.claude} />
         <span className="text-emerald-200">|</span>
@@ -544,7 +550,7 @@ export function QuotaBadge({
         <HostMetricStrip host={host} />
       </button>
       {open && (
-        <Modal title="cc / Codex 状态" onClose={() => setOpen(false)} wide>
+        <Modal title="cc / Codex / omp 状态" onClose={() => setOpen(false)} wide>
           <div className="space-y-3">
             <div className="grid gap-3 md:grid-cols-2">
               <ProviderDetail
@@ -565,6 +571,18 @@ export function QuotaBadge({
                 engine="codex"
                 tool={tools.codex}
                 toolState={toolStates.codex}
+                onRefreshTool={loadTool}
+                onCheckUpdate={checkUpdate}
+                onUpdateTool={updateTool}
+              />
+              <ProviderDetail
+                label="omp"
+                note="Oh My Pi"
+                q={null}
+                quotaUnsupported
+                engine="omp"
+                tool={tools.omp}
+                toolState={toolStates.omp}
                 onRefreshTool={loadTool}
                 onCheckUpdate={checkUpdate}
                 onUpdateTool={updateTool}

--- a/frontend/src/components/SessionHistoryView.tsx
+++ b/frontend/src/components/SessionHistoryView.tsx
@@ -44,6 +44,13 @@ function parseExportedHistory(bundle: { engine?: string; jsonl?: string }) {
       if (message) append(message.role ?? item.type, contentText(message.content), timestamp);
       continue;
     }
+    if (bundle.engine === "omp") {
+      // omp: {"type":"message","message":{"role":...,"content":[...]}}
+      if (item.type !== "message") continue;
+      const message = item.message as Record<string, unknown> | undefined;
+      if (message) append(message.role, contentText(message.content), timestamp);
+      continue;
+    }
     const payload = item.payload as Record<string, unknown> | undefined;
     if (!payload) continue;
     if (item.type === "event_msg" && (payload.type === "user_message" || payload.type === "agent_message")) {

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -537,7 +537,7 @@ export function SettingsView({
         </Field>
         <Field
           label="自定义参数"
-          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell；--session-dir/--profile 等会挪走会话存储的参数会被拒绝。"
+          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell；会改变会话存储、运行方式、或让 omp 加载不到回报 skill 的参数会被拒绝，密钥请走环境变量。"
         >
           <input
             className="w-72 font-mono text-xs"

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -354,6 +354,7 @@ export function SettingsView({
   });
   const [restartingBackend, setRestartingBackend] = useState(false);
 
+  // omp 没有可消费的模型目录接口，设置页直接填模型 ID，这里只服务 cc/codex。
   async function refreshModels(engine: "cc" | "codex") {
     if (refreshingModels[engine]) return;
 
@@ -485,6 +486,31 @@ export function SettingsView({
             onChange={(e) => void onChange({ codex_effort: e.target.value })}
           >
             {settings.codex_effort_options.map((opt) => (
+              <option key={opt.value || "default"} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </Section>
+
+      <Section title="Oh My Pi" hint="模型与思考档位。omp 的模型名跨 provider 模糊匹配，可直接填写。">
+        <Field label="模型">
+          <ModelCombobox
+            id="omp-model"
+            value={settings.omp_model}
+            options={settings.omp_model_options}
+            onChange={(value) => onSettingsPatch({ omp_model: value })}
+            onCommit={(value) => void onChange({ omp_model: value })}
+          />
+        </Field>
+        <Field label="思考档位">
+          <select
+            className="w-28"
+            value={settings.omp_thinking}
+            onChange={(e) => void onChange({ omp_thinking: e.target.value })}
+          >
+            {settings.omp_thinking_options.map((opt) => (
               <option key={opt.value || "default"} value={opt.value}>
                 {opt.label}
               </option>

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -360,6 +360,18 @@ export function SettingsView({
     setOmpExtraArgs(settings.omp_extra_args);
   }, [settings.omp_extra_args]);
 
+  // 后端会拒绝改变会话存储位置的参数(--session-dir/--profile 等)，
+  // 被拒时要把原因显示出来并回退输入框，否则用户以为已经生效。
+  async function saveOmpExtraArgs() {
+    if (ompExtraArgs === settings.omp_extra_args) return;
+    try {
+      await onChange({ omp_extra_args: ompExtraArgs });
+    } catch (err) {
+      setOmpExtraArgs(settings.omp_extra_args);
+      toast(`自定义参数未保存：${readDetail(err)}`, "error");
+    }
+  }
+
   // omp 没有可消费的模型目录接口，设置页直接填模型 ID，这里只服务 cc/codex。
   async function refreshModels(engine: "cc" | "codex") {
     if (refreshingModels[engine]) return;
@@ -525,16 +537,14 @@ export function SettingsView({
         </Field>
         <Field
           label="自定义参数"
-          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell，只接受选项，别填指令内容。"
+          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell；--session-dir/--profile 等会挪走会话存储的参数会被拒绝。"
         >
           <input
             className="w-72 font-mono text-xs"
             value={ompExtraArgs}
             placeholder="--advisor --no-lsp"
             onChange={(e) => setOmpExtraArgs(e.target.value)}
-            onBlur={() => {
-              if (ompExtraArgs !== settings.omp_extra_args) void onChange({ omp_extra_args: ompExtraArgs });
-            }}
+            onBlur={() => void saveOmpExtraArgs()}
           />
         </Field>
       </Section>

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -353,6 +353,12 @@ export function SettingsView({
     codex: false,
   });
   const [restartingBackend, setRestartingBackend] = useState(false);
+  // 自定义参数按整行提交（失焦时），避免每敲一个字符就写一次库
+  const [ompExtraArgs, setOmpExtraArgs] = useState(settings.omp_extra_args);
+
+  useEffect(() => {
+    setOmpExtraArgs(settings.omp_extra_args);
+  }, [settings.omp_extra_args]);
 
   // omp 没有可消费的模型目录接口，设置页直接填模型 ID，这里只服务 cc/codex。
   async function refreshModels(engine: "cc" | "codex") {
@@ -516,6 +522,20 @@ export function SettingsView({
               </option>
             ))}
           </select>
+        </Field>
+        <Field
+          label="自定义参数"
+          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell，只接受选项，别填指令内容。"
+        >
+          <input
+            className="w-72 font-mono text-xs"
+            value={ompExtraArgs}
+            placeholder="--advisor --no-lsp"
+            onChange={(e) => setOmpExtraArgs(e.target.value)}
+            onBlur={() => {
+              if (ompExtraArgs !== settings.omp_extra_args) void onChange({ omp_extra_args: ompExtraArgs });
+            }}
+          />
         </Field>
       </Section>
 

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -353,25 +353,6 @@ export function SettingsView({
     codex: false,
   });
   const [restartingBackend, setRestartingBackend] = useState(false);
-  // 自定义参数按整行提交（失焦时），避免每敲一个字符就写一次库
-  const [ompExtraArgs, setOmpExtraArgs] = useState(settings.omp_extra_args);
-
-  useEffect(() => {
-    setOmpExtraArgs(settings.omp_extra_args);
-  }, [settings.omp_extra_args]);
-
-  // 后端会拒绝改变会话存储位置的参数(--session-dir/--profile 等)，
-  // 被拒时要把原因显示出来并回退输入框，否则用户以为已经生效。
-  async function saveOmpExtraArgs() {
-    if (ompExtraArgs === settings.omp_extra_args) return;
-    try {
-      await onChange({ omp_extra_args: ompExtraArgs });
-    } catch (err) {
-      setOmpExtraArgs(settings.omp_extra_args);
-      toast(`自定义参数未保存：${readDetail(err)}`, "error");
-    }
-  }
-
   // omp 没有可消费的模型目录接口，设置页直接填模型 ID，这里只服务 cc/codex。
   async function refreshModels(engine: "cc" | "codex") {
     if (refreshingModels[engine]) return;
@@ -534,18 +515,6 @@ export function SettingsView({
               </option>
             ))}
           </select>
-        </Field>
-        <Field
-          label="自定义参数"
-          hint="原样传给 omp，如 --smol haiku --advisor --max-time 30m。不经过 shell；会改变会话存储、运行方式、或让 omp 加载不到回报 skill 的参数会被拒绝，密钥请走环境变量。"
-        >
-          <input
-            className="w-72 font-mono text-xs"
-            value={ompExtraArgs}
-            placeholder="--advisor --no-lsp"
-            onChange={(e) => setOmpExtraArgs(e.target.value)}
-            onBlur={() => void saveOmpExtraArgs()}
-          />
         </Field>
       </Section>
 

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -21,7 +21,7 @@ import { guardQuota } from "../quota";
 import { TERMINAL_SUBMIT_KEY, buildTerminalSubmitSequence } from "../terminalInput";
 import { installHardWrappedWebLinkProvider } from "../terminalLinks";
 import { STATUS_STYLE, taskStatusStyleKey } from "../theme";
-import type { ReplySuggestion, Task } from "../types";
+import type { Engine, ReplySuggestion, Task } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
 import { taskPromptText } from "../taskText";
 
@@ -1572,7 +1572,7 @@ export function TerminalPanel({
     });
   }
 
-  async function switchEngine(target: "cc" | "codex") {
+  async function switchEngine(target: Engine) {
     if (target === detail.engine) return;
     await run(async () => {
       if (!(await guardQuota(target))) return;
@@ -1731,11 +1731,12 @@ export function TerminalPanel({
             className="shrink-0 rounded border border-slate-200 bg-slate-100 px-1.5 py-0.5 text-xs font-medium uppercase text-slate-600 disabled:opacity-50"
             value={detail.engine}
             disabled={busy}
-            onChange={(e) => void switchEngine(e.target.value as "cc" | "codex")}
+            onChange={(e) => void switchEngine(e.target.value as Engine)}
             title={detail.status === "draft" ? "切换任务执行器" : "切换执行器并创建接力任务"}
           >
             <option value="cc">CC</option>
             <option value="codex">Codex</option>
+            <option value="omp">OMP</option>
           </select>
           <span className={`shrink-0 whitespace-nowrap text-sm font-medium ${s.text}`}>{s.label}</span>
           {canSwitch && (

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -24,6 +24,7 @@ import { STATUS_STYLE, taskStatusStyleKey } from "../theme";
 import type { Engine, ReplySuggestion, Task } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
 import { taskPromptText } from "../taskText";
+import { engineShort } from "../engines";
 
 // 「其他任务需要处理」提醒：同一轮等待只弹一次，关闭或跳转后不再打扰。
 // 用 任务id + 该轮等待起点 作 key（waiting_since 在任务离开 waiting_input 时清空，
@@ -1583,7 +1584,7 @@ export function TerminalPanel({
         return;
       }
       const activeNow = ["queued", "running", "waiting_input"].includes(detail.status);
-      const targetLabel = target === "cc" ? "CC" : "Codex";
+      const targetLabel = engineShort(target);
       const message = activeNow
         ? `切换到 ${targetLabel} 接力？当前执行器会停止，原任务会保留。`
         : `创建一个 ${targetLabel} 接力任务？原任务会保留。`;

--- a/frontend/src/engines.ts
+++ b/frontend/src/engines.ts
@@ -1,0 +1,29 @@
+import type { Engine } from "./types";
+
+/** 引擎展示元数据。新增引擎只改这里，避免各处散落 `cc ? A : B` 的二值兜底。 */
+const ENGINE_META: Record<Engine, { name: string; short: string; badge: string }> = {
+  cc: { name: "Claude Code", short: "CC", badge: "bg-violet-50 text-violet-600" },
+  codex: { name: "Codex", short: "Codex", badge: "bg-emerald-50 text-emerald-600" },
+  omp: { name: "Oh My Pi", short: "OMP", badge: "bg-sky-50 text-sky-600" },
+};
+
+const FALLBACK = { name: "未知引擎", short: "?", badge: "bg-slate-100 text-slate-500" };
+
+function meta(engine: string) {
+  return ENGINE_META[engine as Engine] ?? { ...FALLBACK, name: engine || FALLBACK.name };
+}
+
+/** 完整名称，用于提示语与标题。 */
+export function engineName(engine: string): string {
+  return meta(engine).name;
+}
+
+/** 短标签，用于徽标与按钮。 */
+export function engineShort(engine: string): string {
+  return meta(engine).short;
+}
+
+/** 徽标配色。 */
+export function engineBadgeClass(engine: string): string {
+  return meta(engine).badge;
+}

--- a/frontend/src/quota.ts
+++ b/frontend/src/quota.ts
@@ -3,6 +3,8 @@ import { confirmDialog } from "./overlay";
 
 /** 执行前限额守卫：目标引擎任一用量窗口超阈值则弹确认。返回是否继续。engine 省略=查全部。 */
 export async function guardQuota(engine?: string): Promise<boolean> {
+  // omp 自带 provider 凭据，没有订阅额度接口，拿 codex 的额度拦它是错的。
+  if (engine === "omp") return true;
   try {
     const q = await api.quota(engine);
     const limit = q.block_pct ?? 90;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -33,10 +33,13 @@ export type TaskStatus =
 
 export type TaskWaitingKind = "permission" | "choice" | "input" | "review";
 
+/** 可执行任务的引擎：Claude Code / Codex CLI / Oh My Pi。 */
+export type Engine = "cc" | "codex" | "omp";
+
 export interface Task {
   id: number;
   project_id: number;
-  engine: "cc" | "codex";
+  engine: Engine;
   prompt: string;
   title: string | null;
   priority: number;
@@ -84,7 +87,7 @@ export interface SessionHistoryMessage {
 }
 
 export interface LocalSession {
-  engine: "cc" | "codex";
+  engine: Engine;
   session_uid: string;
   title: string;
   prompt: string;


### PR DESCRIPTION
## 背景

在 Claude Code / Codex 之外，增加 [oh-my-pi](https://github.com/can1357/oh-my-pi)（CLI 名 `omp`）作为第三个执行引擎。

接入前实装 omp 17.2.7 摸清了 CLI 与会话语义（验证完已卸载）：

- 参数：`--auto-approve` / `-p` / `--mode json`（逐事件 NDJSON）/ `--resume <id 前缀>`
- 会话：`~/.omp/agent/sessions/<scope>-<名>-<sha256(真实路径)>/<时间戳>_<uuid>.jsonl`，
  头部含 `id`/`cwd`/`timestamp`，消息自带增量 `usage`（`input`/`output`/`cacheRead`/`cacheWrite`/`cost`）
- skills：`skills.enableClaudeUser` 默认 true 且加载器扫 `~/.claude/skills`，`bosun-report` 无需改动即可被发现

## 改动

**引擎接入**
- `config.OMP_BIN` + `BOSUN_OMP_BIN` 覆盖
- `engines.py` 四个 argv 构建加 omp 分支；运行时 flag 按前缀插入，避免落在位置参数之后
- `sessions.py` 会话定位 / 捕获 / 历史 / token 全接入；omp 的 usage 是逐条增量，直接累加
- `autopilot` 复审判定先抽助手正文再匹配（原始事件流里夹着被回显的提示词）
- `engine_updates` 版本检查与 npm 更新；omp 无模型目录，更新后不再误报刷新失败
- 设置页新增 omp 模型与思考档位

**顺带修掉的既有问题**
- 引擎二值兜底：`sessions.py` 多处 `if cc … else`（默认落 codex），omp 会被静默当成 codex
- 前端新增 `engines.ts` 统一引擎元数据，替换 5 处 `cc ? A : Codex` 三元式——omp 此前在任务卡徽标、切换提示、导入对话框里都显示成 Codex；omp 会话历史会走 codex 解析器解出空白
- **cc/omp 同项目并发任务会串号 / 互换**：认领改到锁内、排除已认领 uid、比对首条 prompt，并按 transcript 自记的创建时间归属（cc 原本也有此缺陷）
- 会话捕获不再限定 45s：任务存活期间持续轮询，退出后再补几次；晚于结算认领时补跑一次 token 结算
- `codex exec --json` 的复审输出解析按实跑修正为 `item.completed.item.text`

## 边界

- omp 自带 provider 凭据、无订阅额度接口 → 不参与额度阈值拦截与自动选引擎，额度徽标标注"无额度接口"
- omp 依赖 Bun 运行时，安装体积实测约 1.1 GB（`--omit=optional` 挡不住 onnx / 语音那 285 MB）
- omp 启动会自动继承 `~/.claude` 配置，包括已配置的 MCP server，已在 README 安全说明中标注

## 关于自定义参数功能

原计划一并提供"设置页填任意 omp 原生参数"，实现后连续两轮审查都在其参数校验上发现新的漏网项（`--session` / `--fork` / `--yolo` 等别名、`--tools read` 这类合法过滤器同样会让 `bosun-report` 跑不起来）。

根因是**用黑名单围堵一个无法穷举的 CLI 表面**：omp 约 50 个 flag，别名与等价写法靠推断列不全，而验证机上已卸载 omp 无从核对。这不是修得不够仔细，是方法本身不成立。

该功能已从本 PR 摘出，完整实现连同六轮修复保留在 `feat/omp-extra-args` 分支，待装上 omp 核对真实参数表后改用**白名单**重做。

## 验证

```
后端  backend/.venv/bin/python -m unittest discover -s tests -t .
      → Ran 383 tests，仅 2 个失败且均为改动前既有：
        - test_terminal_ws 时序（clean tree 上同样失败，已复现确认）
        - test_start_script 缺 pytest 模块（环境问题）
前端  npm run build（tsc -b && vite build）→ ✓ 通过
新增  tests/test_omp_engine.py 36 个用例；另补 capture_cc_session 回归测试
      （该函数此前只被 mock、从未真跑，而本 PR 重构了它）
交叉  codex exec review 独立审查 6 轮，累计 17 条发现全部处理或转入后续分支
```

注：`tests/` 被 `.gitignore:25` 排除在开源产物外，故测试文件不在本 PR 的 diff 中。

## 已知局限（未验证，非阻塞）

1. **端到端未跑通**。omp 已卸载，当前的绿是单测与构建的绿，不是"真起一个 omp 任务跑通"。需重装 omp（1.1 GB + Bun）并配置 provider API key 才能补。
2. **`PI_CODING_AGENT_SESSION_DIR` 的确切语义未实测**。omp 可能把会话直接写在该目录下、也可能仍按 `<scope>-<名>-<hash>` 分桶，代码对两种布局都做了扫描而非赌其一。
3. **omp 若是「启动器 + 本体」双进程结构**（如 `omp → omp`），已合入的嵌套回报守卫（#2）会把 omp 任务的正常回报误判为嵌套并拒掉。claude（单 `claude` 进程）与 codex（`node → codex`，node 不计）已确认不受影响，omp 未实测。装上 omp 后应优先验证这一条。