### PR TITLE
feat: Windows 平台适配 + macOS Intel 构建

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           name: linux
           path: bosun-*.tar.gz
+          retention-days: 1  # 中转件：release 挂载后即无用
 
   macos:
     strategy:
@@ -110,6 +111,7 @@ jobs:
           path: |
             Bosun-*.dmg
             bosun-*.app.tar.gz
+          retention-days: 1
 
   windows:
     runs-on: windows-2022
@@ -153,6 +155,7 @@ jobs:
         with:
           name: windows
           path: bosun-*.zip
+          retention-days: 1
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         include:
           - runner: macos-14
             arch: arm64
-          - runner: macos-13
+          - runner: macos-15-intel  # macos-13 已退役，这是 GitHub 现存的 Intel 镜像
             arch: x86_64
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: write
 
+env:
+  # tag 构建用 tag 名；workflow_dispatch 的分支名带斜杠不能进文件名，统一用 dev
+  REF: ${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+
 jobs:
   linux:
     runs-on: ubuntu-22.04
@@ -48,7 +52,7 @@ jobs:
           curl -fsS http://127.0.0.1:8770/ | grep -q "<title>" || exit 1
           kill %1
       - name: 压缩产物
-        run: tar -C dist -czf "bosun-${{ github.ref_name }}-linux-x86_64.tar.gz" bosun
+        run: tar -C dist -czf "bosun-${REF}-linux-x86_64.tar.gz" bosun
       - uses: actions/upload-artifact@v4
         with:
           name: linux
@@ -98,8 +102,8 @@ jobs:
           cp -R macos/build/Bosun.app staging/
           ln -s /Applications staging/Applications
           hdiutil create -volname Bosun -srcfolder staging -ov -format UDZO \
-            "Bosun-${{ github.ref_name }}-macos-${{ matrix.arch }}.dmg"
-          tar -C macos/build -czf "bosun-${{ github.ref_name }}-macos-${{ matrix.arch }}.app.tar.gz" Bosun.app
+            "Bosun-${REF}-macos-${{ matrix.arch }}.dmg"
+          tar -C macos/build -czf "bosun-${REF}-macos-${{ matrix.arch }}.app.tar.gz" Bosun.app
       - uses: actions/upload-artifact@v4
         with:
           name: macos-${{ matrix.arch }}
@@ -144,7 +148,7 @@ jobs:
           kill %1 || true
       - name: 压缩产物
         shell: pwsh
-        run: Compress-Archive -Path dist/bosun -DestinationPath "bosun-${{ github.ref_name }}-windows-x86_64.zip"
+        run: Compress-Archive -Path dist/bosun -DestinationPath "bosun-$env:REF-windows-x86_64.zip"
       - uses: actions/upload-artifact@v4
         with:
           name: windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
-# 打 tag（v*）时构建 macOS / Linux 免源码可执行产物并挂到 GitHub Release。
+# 打 tag（v*）时构建 macOS / Linux / Windows 免源码可执行产物并挂到 GitHub Release；
+# workflow_dispatch 可在任意分支手动跑构建与冒烟（不发布），用于合并前验证。
 # 产物命名是在线更新的契约（backend/app/self_update.py 按后缀匹配平台），不要随意改：
-#   Bosun-<tag>-macos-arm64.dmg          （macOS 用户手动安装）
-#   bosun-<tag>-macos-arm64.app.tar.gz   （macOS 在线更新 / 命令行安装）
-#   bosun-<tag>-linux-x86_64.tar.gz      （Linux）
+#   Bosun-<tag>-macos-arm64.dmg / Bosun-<tag>-macos-x86_64.dmg    （macOS 用户手动安装）
+#   bosun-<tag>-macos-arm64.app.tar.gz / …-x86_64.app.tar.gz      （macOS 在线更新）
+#   bosun-<tag>-linux-x86_64.tar.gz                               （Linux）
+#   bosun-<tag>-windows-x86_64.zip                                （Windows）
 name: release
 
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -52,7 +55,14 @@ jobs:
           path: bosun-*.tar.gz
 
   macos:
-    runs-on: macos-14
+    strategy:
+      matrix:
+        include:
+          - runner: macos-14
+            arch: arm64
+          - runner: macos-13
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -88,17 +98,61 @@ jobs:
           cp -R macos/build/Bosun.app staging/
           ln -s /Applications staging/Applications
           hdiutil create -volname Bosun -srcfolder staging -ov -format UDZO \
-            "Bosun-${{ github.ref_name }}-macos-arm64.dmg"
-          tar -C macos/build -czf "bosun-${{ github.ref_name }}-macos-arm64.app.tar.gz" Bosun.app
+            "Bosun-${{ github.ref_name }}-macos-${{ matrix.arch }}.dmg"
+          tar -C macos/build -czf "bosun-${{ github.ref_name }}-macos-${{ matrix.arch }}.app.tar.gz" Bosun.app
       - uses: actions/upload-artifact@v4
         with:
-          name: macos
+          name: macos-${{ matrix.arch }}
           path: |
             Bosun-*.dmg
             bosun-*.app.tar.gz
 
+  windows:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: 构建前端
+        shell: bash
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: 打包后端
+        shell: bash
+        run: |
+          pip install -r backend/requirements.txt pyinstaller
+          python -m PyInstaller packaging/bosun.spec --noconfirm
+      - name: 冒烟测试
+        shell: bash
+        run: |
+          ./dist/bosun/bosun.exe &
+          for i in $(seq 1 45); do
+            curl -fsS http://127.0.0.1:8770/api/health && break
+            sleep 1
+          done
+          curl -fsS http://127.0.0.1:8770/api/health || exit 1
+          curl -fsS http://127.0.0.1:8770/ | grep -q "<title>" || exit 1
+          kill %1 || true
+      - name: 压缩产物
+        shell: pwsh
+        run: Compress-Archive -Path dist/bosun -DestinationPath "bosun-${{ github.ref_name }}-windows-x86_64.zip"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: bosun-*.zip
+
   release:
-    needs: [linux, macos]
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [linux, macos, windows]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/download-artifact@v4
@@ -108,16 +162,19 @@ jobs:
         with:
           files: |
             bosun-*.tar.gz
+            bosun-*.zip
             Bosun-*.dmg
           body: |
             ## 安装说明
 
-            **macOS（Apple Silicon）**：下载 `.dmg`，拖入「应用程序」。产物未做 Apple 公证，首次打开若被 Gatekeeper 拦截，执行：
+            **macOS**：下载对应芯片的 `.dmg`（Apple Silicon 选 `arm64`，Intel 选 `x86_64`），拖入「应用程序」。产物未做 Apple 公证，首次打开若被 Gatekeeper 拦截，执行：
             ```bash
             xattr -cr /Applications/Bosun.app
             ```
 
             **Linux（x86_64）**：下载 `.tar.gz` 解压后运行 `./bosun/bosun`，浏览器访问 `http://127.0.0.1:8770`。
+
+            **Windows（x86_64，beta）**：下载 `.zip` 解压后运行 `bosun\bosun.exe`，浏览器访问 `http://127.0.0.1:8770`。
 
             运行 AI 编码任务仍需自行安装至少一种支持的 CLI（Claude Code / Codex / Oh My Pi / Kimi Code 等）。
           append_body: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Release](https://img.shields.io/github/v/release/thsrite/bosun?color=2dd4bf&label=release)](https://github.com/thsrite/bosun/releases)
 [![License](https://img.shields.io/github/license/thsrite/bosun?color=blue)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-8a94a6)](#-快速开始)
+[![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-8a94a6)](#-快速开始)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-2dd4bf)](#-参与贡献)
 
 [快速开始](#-快速开始) · [界面预览](#-界面预览) · [用法](#-用法) · [配置](#%EF%B8%8F-配置) · [设计文档](docs/bosun-design.md)
@@ -78,12 +78,13 @@ _以上截图使用完全虚构的项目、路径、任务、终端输出和系�
 
 | 平台 | 产物 | 安装 |
 |---|---|---|
-| macOS（Apple Silicon） | `Bosun-*-macos-arm64.dmg` | 拖入「应用程序」，菜单栏出现「>~」图标即可用 |
+| macOS（Apple Silicon / Intel） | `Bosun-*-macos-arm64.dmg` / `…-x86_64.dmg` | 按芯片选对应 DMG，拖入「应用程序」，菜单栏出现「>~」图标即可用 |
 | Linux（x86_64） | `bosun-*-linux-x86_64.tar.gz` | 解压后 `./bosun/bosun`，浏览器访问 `http://127.0.0.1:8770` |
+| Windows（x86_64，beta） | `bosun-*-windows-x86_64.zip` | 解压后运行 `bosun\bosun.exe`，浏览器访问 `http://127.0.0.1:8770` |
 
 > macOS 产物未做 Apple 公证，首次打开被 Gatekeeper 拦截时执行：`xattr -cr /Applications/Bosun.app`
 
-二进制版同样支持「设置 → Bosun 版本」在线更新（整包替换）。
+macOS / Linux 二进制版同样支持「设置 → Bosun 版本」在线更新（整包替换）；Windows 版暂需手动下载新版替换。Windows 属 beta：等待/接管的识别启发式在 ConPTY 下仍在打磨，源码运行方式暂只支持 macOS / Linux（`start.sh` 依赖 bash）。
 
 ### 方式二：源码运行
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -88,6 +88,14 @@ def _resolve_bin(env_name: str, default: str, candidates: list[Path]) -> str:
     resolved = shutil.which(default)
     if resolved:
         return resolved
+    if sys.platform == "win32":
+        # npm 全局包在 Windows 落在 %APPDATA%\npm 下的 .cmd shim
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            for ext in (".cmd", ".exe"):
+                shim = Path(appdata) / "npm" / f"{default}{ext}"
+                if shim.is_file():
+                    return str(shim)
     for candidate in candidates:
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate)

--- a/backend/app/engine_models.py
+++ b/backend/app/engine_models.py
@@ -1,16 +1,20 @@
 """Discover model choices exposed by the installed Claude Code / Codex CLI."""
 from __future__ import annotations
 
-import fcntl
 import json
 import os
-import pty
 import re
-import select
 import struct
 import subprocess
-import termios
+import sys
+import threading
 import time
+
+if sys.platform != "win32":
+    import fcntl
+    import pty
+    import select
+    import termios
 
 from . import db
 from .env import child_env
@@ -74,7 +78,68 @@ def parse_claude_model_picker(output: str) -> list[dict[str, str]]:
     return options
 
 
+def _capture_claude_model_picker_windows(binary: str) -> str:
+    """Windows 走 pty_compat（ConPTY）：读线程收流，主循环限时等选择器渲染完。"""
+    from .pty_compat import PtyProcess
+
+    try:
+        proc = PtyProcess.spawn(
+            [binary, "--safe-mode", "--ax-screen-reader"],
+            env=child_env({"TERM": "xterm-256color", "NO_COLOR": "1", "FORCE_COLOR": "0"}),
+            dimensions=(40, 120),
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise ModelDiscoveryError(f"无法启动 Claude CLI：{exc}") from exc
+
+    chunks: list[bytes] = []
+    stop = threading.Event()
+
+    def _pump() -> None:
+        total = 0
+        while not stop.is_set() and total <= _MAX_PICKER_BYTES:
+            try:
+                chunk = proc.read(16_384)
+            except (EOFError, OSError):
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+
+    reader = threading.Thread(target=_pump, daemon=True)
+    reader.start()
+    started_at = time.monotonic()
+    command_sent = False
+    try:
+        while time.monotonic() - started_at < _CLAUDE_PICKER_TIMEOUT_SECONDS:
+            if not command_sent and time.monotonic() - started_at >= 1:
+                proc.write(b"/model\r")
+                command_sent = True
+            output = b"".join(chunks).decode("utf-8", errors="replace")
+            plain = _without_ansi(output)
+            if "Select model" in plain and "Enter to set" in plain:
+                return output
+            if not proc.isalive():
+                break
+            time.sleep(0.2)
+    finally:
+        stop.set()
+        if proc.isalive():
+            try:
+                proc.write(b"\x1b\x03")
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                proc.terminate(force=True)
+            except Exception:  # noqa: BLE001
+                pass
+
+    raise ModelDiscoveryError("读取 Claude CLI 模型选择器超时或提前退出")
+
+
 def _capture_claude_model_picker(binary: str) -> str:
+    if sys.platform == "win32":
+        return _capture_claude_model_picker_windows(binary)
     master_fd, slave_fd = pty.openpty()
     try:
         fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 120, 0, 0))

--- a/backend/app/pty_compat.py
+++ b/backend/app/pty_compat.py
@@ -1,0 +1,72 @@
+"""平台 PTY 适配层：POSIX 用 ptyprocess，Windows 用 pywinpty（ConPTY）。
+
+会话层统一从这里拿 PtyProcess。接口对齐 ptyprocess 的语义：
+read/write 走 bytes，EOF 抛 EOFError，spawn(argv, cwd, env, dimensions)。
+"""
+from __future__ import annotations
+
+import sys
+
+IS_WINDOWS = sys.platform == "win32"
+
+if not IS_WINDOWS:
+    from ptyprocess import PtyProcess  # noqa: F401  # re-export，POSIX 直接用原实现
+else:
+    import shutil
+
+    from winpty import PtyProcess as _WinPtyProcess
+
+    def _normalize_argv(argv: list[str]) -> list[str]:
+        """npm 全局安装的 CLI 在 Windows 上是 .cmd/.bat shim，CreateProcess
+        不能直接执行，须经 cmd /c 包一层。"""
+        resolved = shutil.which(argv[0]) or argv[0]
+        if resolved.lower().endswith((".cmd", ".bat")):
+            return ["cmd.exe", "/c", resolved, *argv[1:]]
+        return [resolved, *argv[1:]]
+
+    class PtyProcess:
+        """包装 pywinpty：pywinpty 的 read/write 是 str 接口（内部已按 UTF-8
+        与 ConPTY 互转），这里统一回 bytes，与 ptyprocess 对齐。"""
+
+        def __init__(self, impl: _WinPtyProcess) -> None:
+            self._impl = impl
+
+        @classmethod
+        def spawn(
+            cls,
+            argv: list[str],
+            cwd: str | None = None,
+            env: dict | None = None,
+            dimensions: tuple[int, int] = (24, 80),
+        ) -> "PtyProcess":
+            clean_env = {str(k): str(v) for k, v in (env or {}).items()}
+            impl = _WinPtyProcess.spawn(
+                _normalize_argv(list(argv)), cwd=cwd, env=clean_env, dimensions=dimensions
+            )
+            return cls(impl)
+
+        def read(self, size: int = 1024) -> bytes:
+            return self._impl.read(size).encode("utf-8", errors="replace")
+
+        def write(self, data: bytes) -> int:
+            return self._impl.write(data.decode("utf-8", errors="replace"))
+
+        def setwinsize(self, rows: int, cols: int) -> None:
+            self._impl.setwinsize(rows, cols)
+
+        def isalive(self) -> bool:
+            return self._impl.isalive()
+
+        def wait(self) -> int | None:
+            return self._impl.wait()
+
+        @property
+        def exitstatus(self) -> int | None:
+            return self._impl.exitstatus
+
+        @property
+        def pid(self) -> int | None:
+            return getattr(self._impl, "pid", None)
+
+        def terminate(self, force: bool = False) -> bool:
+            return self._impl.terminate(force=force)

--- a/backend/app/pty_session.py
+++ b/backend/app/pty_session.py
@@ -21,9 +21,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Callable
 
-import ptyprocess
-
 from .config import IDLE_SECONDS
+from .pty_compat import PtyProcess
 
 # PTY logs contain every TUI repaint. A long Codex/Claude session can therefore
 # grow to tens of megabytes even though xterm only needs the latest screen and
@@ -326,7 +325,7 @@ class PtySession:
         self.on_exit = on_exit      # (task_id, exit_code)
         self.script_log_path: str | None = None
 
-        self.proc: ptyprocess.PtyProcess | None = None
+        self.proc: PtyProcess | None = None
         self.subscribers: set[asyncio.Queue] = set()
         self.last_output = time.time()
         self._busy_until = 0.0
@@ -368,7 +367,7 @@ class PtySession:
                 Path(script_log_path).unlink(missing_ok=True)
             except OSError:
                 pass
-        self.proc = ptyprocess.PtyProcess.spawn(
+        self.proc = PtyProcess.spawn(
             spawn_argv, cwd=self.cwd, env=env, dimensions=(30, 100)
         )
         self._reader = threading.Thread(target=self._read_loop, daemon=True)

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -7,11 +7,16 @@
 from __future__ import annotations
 
 import asyncio
-import fcntl
 import os
+import sys
 import threading
 import time
 from pathlib import Path
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
 
 from . import db, engine_settings, events, sessions
 from .config import DATA_DIR, LOG_DIR
@@ -49,8 +54,13 @@ def _try_acquire_scheduler_file_lock(path: Path):
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_file = open(path, "a+", encoding="utf-8")
     try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
+        if sys.platform == "win32":
+            # Windows 无 flock：锁文件头 1 字节，进程退出由系统释放，语义等价
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
         lock_file.close()
         return None
     return lock_file

--- a/backend/app/self_update.py
+++ b/backend/app/self_update.py
@@ -131,6 +131,10 @@ def _repo_state() -> dict:
 
 def _blockers(state: dict) -> list[str]:
     if state.get("binary"):
+        if sys.platform == "win32":
+            # Windows 禁止改名含运行中 exe 的目录，整包替换方案不可用；
+            # 「退出后由脚本换包」的方案见 docs/spec-windows.md M3
+            return ["Windows 版暂不支持在线更新，请下载新版 zip 替换安装目录"]
         if _binary_asset_suffix() is None:
             return ["当前平台没有对应的发行产物，无法在线更新"]
         root = _binary_install_root()
@@ -389,6 +393,8 @@ def _binary_asset_suffix() -> str | None:
     if sys.platform.startswith("linux"):
         arch = "x86_64" if machine in {"x86_64", "amd64"} else machine
         return f"linux-{arch}.tar.gz"
+    if sys.platform == "win32":
+        return "windows-x86_64.zip"
     return None
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi>=0.110
 uvicorn[standard]>=0.29
-ptyprocess>=0.7
+ptyprocess>=0.7; sys_platform != "win32"
+pywinpty>=2.0; sys_platform == "win32"
 certifi>=2024.0
 claude-agent-sdk>=0.2
 openai>=2.0

--- a/backend/run.py
+++ b/backend/run.py
@@ -5,8 +5,13 @@
 ⚠️ 0.0.0.0 = 局域网内任何设备都能访问并驱动 cc/codex，请仅在可信网络使用。
 """
 import os
+import sys
 
 import uvicorn
+
+# Windows 控制台默认代码页可能不是 UTF-8，中文日志会抛编码错误
+if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(errors="replace")
 
 # 直接导入 app 对象而非 "app.main:app" 字符串：
 # PyInstaller 靠静态导入图收集依赖，字符串导入在冻结包内会找不到模块。

--- a/bosun_skills/bosun-report/SKILL.md
+++ b/bosun_skills/bosun-report/SKILL.md
@@ -38,6 +38,13 @@ description: 向 Bosun 工作台回报当前任务的最终状态。仅当你正
   bash scripts/report.sh --status needs_input --summary "一句话说清等用户拍板什么" --needs-reply
   ```
 
+Windows 上没有 bash 时改用 PowerShell 版（同一契约）：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/report.ps1 -Status done -Summary "一句话说清你做了什么"
+# needs_input 时追加 -NeedsReply
+```
+
 `summary` 用一句话（≤200 字）说清结论。脚本会先把状态和同一份 summary 打印到 agent 终端，再回调 Bosun；同时会自动处理引号转义，直接写自然语言即可。
 脚本在非 Bosun 会话里会自动空转，安全无副作用。
 

--- a/bosun_skills/bosun-report/scripts/report.ps1
+++ b/bosun_skills/bosun-report/scripts/report.ps1
@@ -1,0 +1,34 @@
+# Bosun 任务状态回调（Windows / PowerShell 版，与 report.sh 同一契约）。
+# 用法: powershell -File report.ps1 -Status <done|failed|needs_input> -Summary "<一句话>" [-NeedsReply]
+param(
+    [string]$Status = "done",
+    [string]$Summary = "",
+    [switch]$NeedsReply
+)
+
+# 守卫：不是 Bosun 派发的会话 → 静默 no-op。
+if (-not $env:BOSUN_TASK_ID -or -not $env:BOSUN_API) { exit 0 }
+
+# 先把同一份汇报留在 agent 终端，再回调 Bosun。
+Write-Output "Bosun 汇报 [$Status]: $Summary"
+
+$payload = @{
+    result       = $Status
+    summary      = $Summary
+    needs_reply  = [bool]$NeedsReply
+    reporter_pid = $PID
+} | ConvertTo-Json -Compress
+
+$headers = @{}
+if ($env:BOSUN_TASK_TOKEN) { $headers["Authorization"] = "Bearer $($env:BOSUN_TASK_TOKEN)" }
+
+try {
+    Invoke-RestMethod -Method Post -TimeoutSec 10 `
+        -Uri "$($env:BOSUN_API)/api/tasks/$($env:BOSUN_TASK_ID)/report" `
+        -ContentType "application/json; charset=utf-8" `
+        -Headers $headers -Body ([System.Text.Encoding]::UTF8.GetBytes($payload)) | Out-Null
+    Write-Output "回报已送达。请紧接着把本轮完整结论正文作为你最后一条消息打印出来再停下（不得再调工具）；summary 只是回执，用户只看正文。"
+} catch {
+    Write-Error "Bosun 回报失败($($_.Exception.Message))：状态没同步到工作台，请直接告知用户。"
+    exit 1
+}

--- a/docs/spec-windows.md
+++ b/docs/spec-windows.md
@@ -1,6 +1,6 @@
 # Windows 版规划（二期）
 
-> 状态：规划中，未实施。一期（v0.2.0）已发 macOS / Linux 二进制，本文规划 Windows exe 的移植路线。
+> 状态：M0–M2 已在 `feat/windows-support` 分支实现（pty_compat 双轨、锁 shim、CI windows job + macOS Intel 矩阵、报告脚本 PowerShell 版）；M1 的 ConPTY 启发式表现待 Windows 真机验证，Windows 版标注 beta。M3（在线自更新）未实施。
 
 ## 目标与非目标
 

--- a/macos/build.sh
+++ b/macos/build.sh
@@ -139,7 +139,9 @@ enum BosunConfig {
 }
 EOF
 
+# 显式钉最低部署版本：swiftc 默认按构建机系统版本，若在新系统上构建会拒绝老系统运行
 xcrun swiftc -O -whole-module-optimization \
+  -target "$(uname -m)-apple-macos13.0" \
   "$MACOS_DIR/Sources/main.swift" "$BUILD_DIR/Config.swift" \
   -o "$APP_DIR/Contents/MacOS/Bosun"
 


### PR DESCRIPTION
## 变更摘要

- **Windows 适配（M0–M2）**：新增 `pty_compat.py` 双轨适配层（POSIX 走 ptyprocess，Windows 走 pywinpty/ConPTY，npm `.cmd` shim 经 `cmd /c` 包装）；`engine_models.py` 平台分支；调度锁 `msvcrt` shim；`%APPDATA%\npm` 引擎探测；Windows 在线更新暂禁（提示手动替换，方案见 docs/spec-windows.md M3）；bosun-report skill 增 PowerShell 版
- **macOS Intel**：CI 矩阵增 `macos-15-intel`（macos-13 runner 已退役）；`swiftc` 钉 `-target macos13.0` 防最低部署版本随构建机漂移
- **CI**：windows job（构建 + 起服务冒烟）、`workflow_dispatch` 分支验证入口、产物命名兼容 dispatch、中转产物保留期 1 天

## 验证证据

- 分支 CI run 31150049919 **全绿**：linux / macos arm64 / macos x86_64(Intel) / windows 四平台构建 + 冒烟（起服务 → /api/health → 首页 title）全部 success
- macOS 本地回归：py_compile 通过；worktree 起后端 health 正常；真实 claude 任务跑通 PTY 链路（与主线基线行为一致进入 waiting_input）
- Windows 为 beta：ConPTY 下等待/接管启发式待真机深度验证（CI 冒烟已覆盖服务层）