### PR TITLE
feat: harness 演进页面化（挖掘/簇/版本回滚 UI + 挖掘口径修正）

### DIFF
--- a/backend/app/harness_mining.py
+++ b/backend/app/harness_mining.py
@@ -74,11 +74,33 @@ def _transcript_tail(log_path: str | None) -> str:
 
 
 def _failed_rows(days: int, limit: int):
+    """失败口径 = 自报 failed ∪ 跑完但未回报（收尾契约失守，实测库里最主要的失败形态；
+    needs_input 是正常反问、cancelled/interrupted 是人为中止，均不算）。"""
     cutoff = time.time() - days * 86400
     return db.query(
-        "SELECT id, engine, report_summary, log_path FROM task "
-        "WHERE report_result='failed' AND COALESCE(ended_at, created_at) >= ? "
+        "SELECT id, engine, report_summary, report_result, log_path FROM task "
+        "WHERE (report_result='failed' OR (report_result IS NULL AND status='done')) "
+        "AND COALESCE(ended_at, created_at) >= ? "
         "ORDER BY id DESC LIMIT ?", (cutoff, limit))
+
+
+# 挖掘运行状态（供 UI 轮询；单机单进程，模块级即可）
+state: dict = {"running": False, "last_run_at": None, "last_clusters": None,
+               "last_proposals": None, "last_error": None}
+
+
+def run_round(cwd: str) -> None:
+    """跑一轮完整的挖掘+提案（在后台线程调用），状态记入 state。"""
+    state.update(running=True, last_error=None)
+    try:
+        clusters = mine(cwd)
+        proposals = propose(cwd)
+        state.update(last_clusters=clusters, last_proposals=proposals)
+    except Exception as e:
+        state.update(last_error=str(e)[:200])
+        raise
+    finally:
+        state.update(running=False, last_run_at=time.time())
 
 
 def mine(cwd: str, days: int = 14, limit: int = 30) -> int:
@@ -87,8 +109,10 @@ def mine(cwd: str, days: int = 14, limit: int = 30) -> int:
     llm = _SdkLLM(cwd, "harness_mining_tokens_total")
     per_engine: dict[str, list] = {}
     for row in _failed_rows(days, limit):
+        summary = row["report_summary"] or (
+            "(任务结束但未按收尾约定回报)" if row["report_result"] is None else "")
         episode = Episode(id=str(row["id"]), engine=row["engine"] or "cc", succeeded=False,
-                          summary=row["report_summary"] or "")
+                          summary=summary)
         sig = extract_signature(llm, episode, _transcript_tail(row["log_path"]))
         if sig:
             per_engine.setdefault(episode.engine, []).append((episode.id, sig))

--- a/backend/app/routers/reflection.py
+++ b/backend/app/routers/reflection.py
@@ -73,6 +73,8 @@ def list_proposals(status: str = "pending"):
 @router.post("/harness/mine")
 def run_harness_mine():
     """后台跑一轮 harness 挖掘+提案（失败任务逐条过 LLM，同步跑会拖死请求）。"""
+    if harness_mining.state["running"]:
+        return {"started": False, "status": "running"}
     proj = db.query_one("SELECT path FROM project LIMIT 1")
     if proj is None:
         raise HTTPException(400, "还没有项目")
@@ -80,15 +82,29 @@ def run_harness_mine():
 
     def _run():
         try:
-            clusters = harness_mining.mine(path)
-            proposals = harness_mining.propose(path)
-            events.emit("proposals.updated", {"harness_clusters": clusters,
-                                              "harness_proposals": proposals})
+            harness_mining.run_round(path)
+            events.emit("proposals.updated", {})
         except Exception:
             logging.getLogger(__name__).exception("harness 挖掘失败")
 
     threading.Thread(target=_run, daemon=True, name="harness-mine").start()
-    return {"started": True}
+    return {"started": True, "status": "started"}
+
+
+@router.get("/harness/status")
+def harness_status():
+    return harness_mining.state
+
+
+@router.get("/harness/versions")
+def list_harness_versions():
+    """各引擎当前生效的 harness 版本（未初始化的引擎不出现）。"""
+    harness_adapter.get_registry()  # 确保 he_* 表存在
+    return [dict(r) for r in db.query(
+        "SELECT engine, version, id, "
+        " (SELECT COUNT(*) FROM he_version v2 WHERE v2.engine=he_version.engine) AS versions_total, "
+        " (SELECT parent_id IS NOT NULL FROM he_version v3 WHERE v3.id=he_version.id) AS can_rollback "
+        "FROM he_version WHERE status='active' ORDER BY engine")]
 
 
 @router.get("/harness/clusters")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -195,6 +195,33 @@ export type ProposalApplyResult = {
   task_id: number | null;
 };
 
+export type HarnessCluster = {
+  id: number;
+  engine: Engine;
+  cause: string;
+  causal: "harness_gap" | "model_limit" | "env_issue" | "user_input";
+  mechanism: string;
+  episode_ids: string[];
+  support: number;
+  created_at: number;
+};
+
+export type HarnessMineStatus = {
+  running: boolean;
+  last_run_at: number | null;
+  last_clusters: number | null;
+  last_proposals: number | null;
+  last_error: string | null;
+};
+
+export type HarnessVersionInfo = {
+  engine: Engine;
+  version: number;
+  id: number;
+  versions_total: number;
+  can_rollback: 0 | 1;
+};
+
 export type HostMetrics = {
   generated_at: number;
   cpu_temp_c: number | null;
@@ -402,6 +429,14 @@ export const api = {
     apply: (id: number) =>
       write<ProposalApplyResult>("POST", `/api/proposals/${id}/apply`),
     dismiss: (id: number, reason = "") => write("POST", `/api/proposals/${id}/dismiss`, { reason }),
+    harness: {
+      mine: () => write<{ started: boolean; status: "started" | "running" }>("POST", "/api/proposals/harness/mine"),
+      status: () => fetch("/api/proposals/harness/status").then((r) => j<HarnessMineStatus>(r)),
+      clusters: () => fetch("/api/proposals/harness/clusters").then((r) => j<HarnessCluster[]>(r)),
+      versions: () => fetch("/api/proposals/harness/versions").then((r) => j<HarnessVersionInfo[]>(r)),
+      rollback: (engine: string) =>
+        write<{ engine: string; active_version: number }>("POST", `/api/proposals/harness/rollback/${encodeURIComponent(engine)}`),
+    },
   },
 
   auth: {

--- a/frontend/src/components/HarnessEvolution.tsx
+++ b/frontend/src/components/HarnessEvolution.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, type HarnessCluster, type HarnessMineStatus, type HarnessVersionInfo } from "../api";
+import { toast } from "../overlay";
+import { useSingleFlight } from "../useSingleFlight";
+
+const CAUSAL_STYLE: Record<HarnessCluster["causal"], { label: string; cls: string }> = {
+  harness_gap: { label: "harness 缺口", cls: "bg-emerald-500/15 text-emerald-400" },
+  model_limit: { label: "模型局限", cls: "bg-amber-500/15 text-amber-400" },
+  env_issue: { label: "环境问题", cls: "bg-sky-500/15 text-sky-400" },
+  user_input: { label: "输入不足", cls: "bg-slate-400/15 text-slate-400" },
+};
+
+/** harness 演进区块：挖掘失败模式 → 失败簇列表 → 各引擎版本与回滚。
+ *  harness_gap 簇会生成提案进上方提案列表（人审采纳才生效），其余簇只展示。 */
+export function HarnessEvolution({ onProposalsChanged }: { onProposalsChanged: () => void }) {
+  const [status, setStatus] = useState<HarnessMineStatus | null>(null);
+  const [clusters, setClusters] = useState<HarnessCluster[]>([]);
+  const [versions, setVersions] = useState<HarnessVersionInfo[]>([]);
+  const [confirmEngine, setConfirmEngine] = useState<string | null>(null);
+  const { busy, run } = useSingleFlight();
+
+  const load = useCallback(async (): Promise<HarnessMineStatus | null> => {
+    const [st, cl, vs] = await Promise.all([
+      api.proposals.harness.status().catch(() => null),
+      api.proposals.harness.clusters().catch(() => [] as HarnessCluster[]),
+      api.proposals.harness.versions().catch(() => [] as HarnessVersionInfo[]),
+    ]);
+    if (st) setStatus(st);
+    setClusters(cl);
+    setVersions(vs);
+    return st;
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // 挖掘运行中轮询；结束时刷新提案列表并报结果
+  useEffect(() => {
+    if (!status?.running) return;
+    const t = window.setInterval(async () => {
+      const st = await load();
+      if (st && !st.running) {
+        onProposalsChanged();
+        if (st.last_error) toast(`挖掘失败：${st.last_error}`, "error");
+        else toast(`挖掘完成：${st.last_clusters ?? 0} 个失败簇，新增 ${st.last_proposals ?? 0} 条提案`, "success");
+      }
+    }, 3000);
+    return () => window.clearInterval(t);
+  }, [status?.running, load, onProposalsChanged]);
+
+  async function mine() {
+    await run(async () => {
+      try {
+        const r = await api.proposals.harness.mine();
+        toast(r.started ? "已开始挖掘，逐条分析失败任务，需几分钟" : "已有挖掘正在运行", "info");
+        await load();
+      } catch (e: any) {
+        toast(`挖掘启动失败：${e.message}`, "error");
+      }
+    });
+  }
+
+  async function rollback(engine: string) {
+    setConfirmEngine(null);
+    await run(async () => {
+      try {
+        const r = await api.proposals.harness.rollback(engine);
+        toast(`${engine} 已回滚到 v${r.active_version}`, "success");
+        await load();
+      } catch (e: any) {
+        toast(`回滚失败：${e.message}`, "error");
+      }
+    });
+  }
+
+  function fmtLast(ts: number | null) {
+    if (!ts) return null;
+    return new Date(ts * 1000).toLocaleString("zh", { hour12: false });
+  }
+
+  const mining = !!status?.running;
+
+  return (
+    <div className="shrink-0 rounded-xl border border-dh-bsoft bg-dh-soft p-3">
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <span className="text-sm font-medium text-dh-text">Harness 演进</span>
+        <button
+          className="rounded-lg bg-dh-accent px-3 py-1 text-xs font-medium text-dh-accfg hover:bg-dh-acchov disabled:opacity-50"
+          disabled={mining || busy}
+          onClick={mine}
+        >
+          {mining ? "挖掘中…" : "挖掘失败模式"}
+        </button>
+        <span className="min-w-0 flex-1 truncate text-xs text-slate-400">
+          {mining
+            ? "正在逐条分析失败任务并聚类，完成后自动刷新"
+            : status?.last_run_at
+              ? `上次：${fmtLast(status.last_run_at)} · ${status.last_clusters ?? 0} 簇 / 新增 ${status.last_proposals ?? 0} 提案${status.last_error ? ` · 失败：${status.last_error}` : ""}`
+              : "分析失败任务 → 聚类失败模式 → harness 缺口自动生成提案（上方列表人审）"}
+        </span>
+      </div>
+
+      {versions.length > 0 && (
+        <div className="mb-2 flex flex-wrap items-center gap-1.5 text-xs">
+          {versions.map((v) => (
+            <span key={v.engine} className="inline-flex items-center gap-1 rounded bg-dh-s2 px-1.5 py-0.5 text-dh-tsoft">
+              {v.engine} · v{v.version}
+              <span className="text-slate-500">/{v.versions_total} 版</span>
+              {!!v.can_rollback &&
+                (confirmEngine === v.engine ? (
+                  <button
+                    className="rounded bg-rose-500/20 px-1 text-rose-400 hover:bg-rose-500/30 disabled:opacity-50"
+                    disabled={busy}
+                    onClick={() => rollback(v.engine)}
+                  >
+                    确认回滚?
+                  </button>
+                ) : (
+                  <button
+                    className="rounded px-1 text-slate-400 hover:bg-dh-hover hover:text-dh-tsoft disabled:opacity-50"
+                    disabled={busy}
+                    onClick={() => setConfirmEngine(v.engine)}
+                  >
+                    回滚
+                  </button>
+                ))}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {clusters.length > 0 && (
+        <div className="max-h-40 space-y-1 overflow-y-auto pr-1">
+          {clusters.map((c) => (
+            <div key={c.id} className="flex items-center gap-1.5 rounded-lg bg-dh-surface px-2 py-1 text-xs">
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${CAUSAL_STYLE[c.causal]?.cls ?? CAUSAL_STYLE.user_input.cls}`}>
+                {CAUSAL_STYLE[c.causal]?.label ?? c.causal}
+              </span>
+              <span className="shrink-0 rounded bg-dh-s2 px-1 py-0.5 text-[10px] text-dh-tsoft">{c.engine}</span>
+              <span className="min-w-0 flex-1 truncate text-dh-tsoft" title={`${c.cause} — ${c.mechanism}`}>
+                {c.cause} — {c.mechanism}
+              </span>
+              <span className="shrink-0 text-slate-400">×{c.support}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ProposalsDialog.tsx
+++ b/frontend/src/components/ProposalsDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { api, type ProposalAction, type ProposalItem, type ReflectionSettings } from "../api";
 import { toast } from "../overlay";
 import { useSingleFlight } from "../useSingleFlight";
+import { HarnessEvolution } from "./HarnessEvolution";
 import { Modal } from "./Modal";
 
 export function ProposalsDialog({ onClose }: { onClose: () => void }) {
@@ -97,6 +98,7 @@ export function ProposalsDialog({ onClose }: { onClose: () => void }) {
   function actionLabel(action: ProposalAction | null) {
     if (!action) return "可转跟进任务";
     if (action.type === "create_task") return "可创建任务";
+    if (action.type === "harness_edit") return "可应用：harness 编辑";
     return `可应用：${action.type}`;
   }
 
@@ -108,6 +110,10 @@ export function ProposalsDialog({ onClose }: { onClose: () => void }) {
       return `策略 #${String(action.policy_id)}.${String(action.field)} = ${JSON.stringify(action.value)}`;
     if (action.type === "create_task")
       return `${String(action.engine ?? "codex")} · ${String(action.title ?? action.prompt ?? "").slice(0, 80)}`;
+    if (action.type === "harness_edit")
+      return `${String(action.engine)} · ${String(action.op)} ${String(action.surface)}/${String(action.entry_key)}${
+        action.value != null ? `\n${String(action.value).slice(0, 200)}` : ""
+      }`;
     return JSON.stringify(action);
   }
 
@@ -191,6 +197,8 @@ export function ProposalsDialog({ onClose }: { onClose: () => void }) {
             </div>
           </div>
         )}
+
+        <HarnessEvolution onProposalsChanged={load} />
 
         <div className="min-h-0 flex-1 space-y-2 overflow-y-auto pr-1">
           {items.length > 0 && (


### PR DESCRIPTION
## 变更摘要

- **前端**：「自进化提案」对话框新增 Harness 演进区块（新组件 HarnessEvolution.tsx）——「挖掘失败模式」按钮（后台运行、3s 轮询、完成 toast 并刷新提案）、失败簇列表（causal 四色徽标：harness 缺口/模型局限/环境问题/输入不足，支持度 ×N）、各引擎当前版本徽标 + 二次确认回滚；harness_edit 提案从 JSON 展示改为「engine · op surface/key + 指令文本」人话展示。
- **后端**：挖掘口径扩为 `report_result='failed'` ∪ 「status=done 且未回报」（收尾契约失守；needs_input/cancelled/interrupted 不算）——实测库中 0 条自报 failed、95 条未回报，原口径首轮挖掘必空转；新增 `GET /harness/status`（运行态+上次结果）与 `GET /harness/versions`（active 版本/总版数/可否回滚），mine 端点加并发防抖。

## 验证证据

- 后端：test_harness_mining 扩至 7 例（新口径含未回报任务、排除 needs_input/cancelled、status/versions 端点、can_rollback 翻转），全绿；全量回归 505 例仅 1 个预存失败（另一任务未提交前端改动的配套断言，与本分支无关）。
- 前端：`npm run build`（tsc -b && vite build）通过。