### PR TITLE
fix: 挖掘聚类失效——加第二遍 LLM 归一化合并（同机制异措辞聚不拢）

### DIFF
--- a/backend/app/harness_mining.py
+++ b/backend/app/harness_mining.py
@@ -17,8 +17,8 @@ import json
 import re
 import time
 
-from backend.harness_evolve import (Episode, Gate0Config, HarnessEdit, gate0_validate,
-                                    cluster_signatures, extract_signature)
+from backend.harness_evolve import (Episode, Gate0Config, HarnessEdit, canonicalize_signatures,
+                                    cluster_signatures, extract_signature, gate0_validate)
 
 from . import db, log_archive, reflection, sdk_run
 from .harness_adapter import REPORT_KEY, get_registry
@@ -103,7 +103,7 @@ def run_round(cwd: str) -> None:
         state.update(running=False, last_run_at=time.time())
 
 
-def mine(cwd: str, days: int = 14, limit: int = 30) -> int:
+def mine(cwd: str, days: int = 14, limit: int = 100) -> int:
     """跑一轮挖掘，harness_cluster 全量重建。返回簇数。"""
     db.get_conn().executescript(_CLUSTER_SCHEMA)
     llm = _SdkLLM(cwd, "harness_mining_tokens_total")
@@ -120,6 +120,8 @@ def mine(cwd: str, days: int = 14, limit: int = 30) -> int:
     db.execute("DELETE FROM harness_cluster")
     n = 0
     for engine, items in per_engine.items():
+        # 二遍归一化：独立抽取的措辞各异，先同义归并再精确聚类，否则全是 support=1
+        items = canonicalize_signatures(llm, items)
         for c in cluster_signatures(items):
             db.execute(
                 "INSERT INTO harness_cluster(engine,cause,causal,mechanism,episode_ids,support,created_at)"

--- a/backend/harness_evolve/__init__.py
+++ b/backend/harness_evolve/__init__.py
@@ -4,8 +4,8 @@
 方案与架构决策见 docs/spec-self-evolving-harness.md。
 """
 from .gates import Gate0Config, gate0_validate, gray_verdict, proportion_diff_ci
-from .mining import (FailureCluster, FailureSignature, actionable_clusters, cluster_signatures,
-                     extract_signature)
+from .mining import (FailureCluster, FailureSignature, actionable_clusters, canonicalize_signatures,
+                     cluster_signatures, extract_signature)
 from .models import (OPS, SURFACES, EditError, Episode, HarnessEdit, HarnessVersion,
                      OutcomeRecord, RenderedHarness)
 from .protocols import ApprovalChannel, HarnessRenderer, LLMClient, OutcomeSignals, TraceSource
@@ -16,7 +16,7 @@ __all__ = [
     "OPS", "SURFACES", "EditError", "Episode", "HarnessEdit", "HarnessVersion",
     "OutcomeRecord", "RenderedHarness", "Registry", "Store",
     "Gate0Config", "gate0_validate", "gray_verdict", "proportion_diff_ci",
-    "FailureCluster", "FailureSignature", "actionable_clusters", "cluster_signatures",
-    "extract_signature",
+    "FailureCluster", "FailureSignature", "actionable_clusters", "canonicalize_signatures",
+    "cluster_signatures", "extract_signature",
     "TraceSource", "OutcomeSignals", "HarnessRenderer", "ApprovalChannel", "LLMClient",
 ]

--- a/backend/harness_evolve/mining.py
+++ b/backend/harness_evolve/mining.py
@@ -59,6 +59,18 @@ def _parse_json(text: str) -> Optional[dict]:
     return data if isinstance(data, dict) else None
 
 
+def _parse_json_array(text: str) -> Optional[list]:
+    text = text.strip()
+    start, end = text.find("["), text.rfind("]")
+    if start < 0 or end <= start:
+        return None
+    try:
+        data = json.loads(text[start:end + 1])
+    except ValueError:
+        return None
+    return data if isinstance(data, list) else None
+
+
 def _norm(value) -> str:
     return re.sub(r"\s+", " ", str(value or "")).strip()
 
@@ -77,6 +89,50 @@ def extract_signature(llm: LLMClient, episode: Episode, transcript: str) -> Opti
     if not cause or not mechanism or causal not in CAUSAL_KINDS:
         return None
     return FailureSignature(cause, causal, mechanism)
+
+
+_CANON_PROMPT = """你是失败模式归并器。以下是从不同失败任务独立抽取的 signature 清单，
+同一失败机制常因措辞不同而无法精确匹配。请把描述同一机制的条目归并，输出唯一一个 JSON 数组（无其它文字）：
+[{{"cause": "规范判因措辞", "causal": "harness_gap|model_limit|env_issue|user_input", "mechanism": "规范机制措辞", "members": [条目编号...]}}]
+
+硬约束：causal 不同的条目绝不可归并到一组；每个编号最多出现在一组；确实独特的条目单独成组；不确定是否同机制时不归并。
+
+条目清单：
+{lines}
+"""
+
+
+def canonicalize_signatures(llm: LLMClient,
+                            items: Iterable[Tuple[str, FailureSignature]]
+                            ) -> List[Tuple[str, FailureSignature]]:
+    """第二遍归一化：独立抽取导致同机制措辞各异、精确匹配聚不拢（实测 30 条全 support=1），
+    用一次 LLM 调用把同义 signature 合并为规范措辞。任何异常/非法输出回退原样（宁可不聚，
+    不错聚）；跨 causal 归并一律拒绝，该成员保留原 signature。"""
+    items = list(items)
+    if len(items) < 2:
+        return items
+    lines = "\n".join(f"{i}. causal={s.causal} | cause={s.cause} | mechanism={s.mechanism}"
+                      for i, (_, s) in enumerate(items))
+    try:
+        groups = _parse_json_array(llm.complete_json(_CANON_PROMPT.format(lines=lines)))
+    except Exception:
+        return items
+    if not groups:
+        return items
+    mapping: dict = {}
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        cause, causal, mechanism = (_norm(group.get("cause")), _norm(group.get("causal")),
+                                    _norm(group.get("mechanism")))
+        if not cause or not mechanism or causal not in CAUSAL_KINDS:
+            continue
+        canonical = FailureSignature(cause, causal, mechanism)
+        for member in group.get("members") or []:
+            if (isinstance(member, int) and 0 <= member < len(items)
+                    and member not in mapping and items[member][1].causal == causal):
+                mapping[member] = canonical
+    return [(episode_id, mapping.get(i, sig)) for i, (episode_id, sig) in enumerate(items)]
 
 
 def cluster_signatures(items: Iterable[Tuple[str, FailureSignature]]) -> List[FailureCluster]:


### PR DESCRIPTION
## 变更摘要

实测首轮挖掘 30 任务出 30 簇、全部 support=1、0 条提案：每条 trace 独立过 LLM，同一失败机制的 mechanism 措辞各异（「收尾回报缺失」「收尾协议遗漏」「收尾阶段未触发回报技能」…），三元组精确匹配一个也聚不拢。

修复：核心包新增 `canonicalize_signatures`——抽取完成后用一次 LLM 调用把同义 signature 归并为规范措辞，再走精确聚类。护栏：跨 causal 归并一律拒绝（成员保留原 signature）；非法输出/编号越界/LLM 异常一律回退原样（宁可不聚、不错聚）；单条输入跳过调用。Bosun 侧 mine() 每引擎归并一次，默认分析上限 30→100（窗口内实有 95 个失败样本）。

## 验证证据

- 核心包新增 4 例（同义归并后可聚类 support=2、跨 causal 归并被拒、三类非法输出+LLM 异常回退恒等、单条不调 LLM）；Bosun 侧新增「同机制异措辞经归并聚成一簇」端到端用例并断言归并调用发生；17 例挖掘相关测试全绿。
- 全量回归 510 例仅 1 个预存失败（test_frontend_pwa，另一任务未提交前端改动的配套断言，与本分支无关）。
- 纯后端改动，无需重建 dist；合并后需重启 Bosun 生效。