### PR TITLE
fix: harness 核心包运行态导入炸裂（正式落地线上热修 + 打包收集）

### DIFF
--- a/backend/app/harness_adapter.py
+++ b/backend/app/harness_adapter.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from backend.harness_evolve import Registry, Store
+# 运行态（run.py / PyInstaller 均以 backend/ 为路径根）核心包是顶层 harness_evolve；
+# tests 以仓库根为路径根，是 backend.harness_evolve。双导入桥接两种上下文。
+try:
+    from harness_evolve import Registry, Store
+except ModuleNotFoundError:
+    from backend.harness_evolve import Registry, Store
 
 from . import db
 from .directives import REPORT_DIRECTIVE

--- a/backend/app/harness_mining.py
+++ b/backend/app/harness_mining.py
@@ -17,8 +17,13 @@ import json
 import re
 import time
 
-from backend.harness_evolve import (Episode, Gate0Config, HarnessEdit, canonicalize_signatures,
-                                    cluster_signatures, extract_signature, gate0_validate)
+# 同 harness_adapter：运行态路径根是 backend/，tests 路径根是仓库根
+try:
+    from harness_evolve import (Episode, Gate0Config, HarnessEdit, canonicalize_signatures,
+                                cluster_signatures, extract_signature, gate0_validate)
+except ModuleNotFoundError:
+    from backend.harness_evolve import (Episode, Gate0Config, HarnessEdit, canonicalize_signatures,
+                                        cluster_signatures, extract_signature, gate0_validate)
 
 from . import db, log_archive, reflection, sdk_run
 from .harness_adapter import REPORT_KEY, get_registry

--- a/packaging/bosun.spec
+++ b/packaging/bosun.spec
@@ -26,6 +26,8 @@ a = Analysis(
         *collect_submodules("uvicorn"),
         "websockets",
         *collect_submodules("claude_agent_sdk"),
+        # harness 演进核心包：app 内经 try/except 双导入引用，静态图可能追不全
+        *collect_submodules("harness_evolve"),
     ],
     excludes=["tkinter"],
 )


### PR DESCRIPTION
## 变更摘要

PR #4 引入的 `from backend.harness_evolve import ...` 只在 tests 上下文（仓库根为路径根）可导入；运行态 run.py 与 PyInstaller 均以 backend/ 为路径根，核心包是顶层 `harness_evolve`，启动即 ModuleNotFoundError——线上已被临时热修（工作区未提交的 try/except 双导入）。本 PR 把该热修正式落地到 harness_adapter/harness_mining（并入 #6 新增的 canonicalize_signatures 导入项），另在 bosun.spec hiddenimports 补 `collect_submodules("harness_evolve")` 防冻结包漏收。

## 验证证据

- tests 上下文：全量 510 例仅 1 个预存失败（test_frontend_pwa，另一任务未提交前端改动的配套断言）。
- 运行态上下文：cwd=backend 下 `import app.harness_adapter, app.harness_mining` 成功，harness_evolve 解析为顶层包。