### PR TITLE
feat: 没装 claude 的机器不生成 ~/.claude（SDK 家目录按需重定向）

### DIFF
--- a/backend/app/routers/claude.py
+++ b/backend/app/routers/claude.py
@@ -9,6 +9,8 @@ from pathlib import Path, PurePosixPath
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from .. import sessions
+
 router = APIRouter(prefix="/api/claude", tags=["claude"])
 
 CLAUDE_HOME = Path.home() / ".claude"
@@ -51,7 +53,13 @@ class ToggleBody(BaseModel):
 
 def _home() -> Path:
     override = os.environ.get("BOSUN_CLAUDE_HOME")
-    return Path(override).expanduser() if override else CLAUDE_HOME
+    if override:
+        return Path(override).expanduser()
+    # 没装 claude CLI 时跟随内置 SDK 的重定向家目录，避免经本页在
+    # 没装 claude 的机器上凭空创建 ~/.claude
+    if sessions.claude_cli_installed():
+        return CLAUDE_HOME
+    return sessions.claude_home()
 
 
 def _disabled_root() -> Path:

--- a/backend/app/sdk_run.py
+++ b/backend/app/sdk_run.py
@@ -15,7 +15,7 @@ from claude_agent_sdk import (
     query,
 )
 
-from . import engine_settings
+from . import engine_settings, sessions
 from .env import child_env
 
 
@@ -30,7 +30,7 @@ def _usage_tokens(usage) -> int:
 async def _run(prompt: str, cwd: str, permission_mode: str, timeout: int, extra_opts: dict | None = None) -> dict:
     opts_kwargs = {
         "cwd": cwd,
-        "env": child_env(),
+        "env": {**child_env(), **sessions.claude_env_overrides()},
         "permission_mode": permission_mode,  # bypassPermissions=全权限, default=按需
     }
     model = engine_settings.claude_model()

--- a/backend/app/sdk_session.py
+++ b/backend/app/sdk_session.py
@@ -29,7 +29,7 @@ from claude_agent_sdk import (
     ToolUseBlock,
 )
 
-from . import engine_settings
+from . import engine_settings, sessions
 from .pty_session import TerminalBacklog
 from .engines import with_report_directive
 from .env import task_env
@@ -101,7 +101,8 @@ class SdkSession:
     def _build_options(self) -> ClaudeAgentOptions:
         opts_kwargs = {
             "cwd": self.cwd,
-            "env": task_env(self.task_id),
+            # 没装 claude CLI 的机器上，捆绑 CLI 家目录重定向进 DATA_DIR（见 sessions.claude_home）
+            "env": {**task_env(self.task_id), **sessions.claude_env_overrides()},
             "permission_mode": "bypassPermissions" if self.auto_approve else "default",
             "can_use_tool": None if self.auto_approve else self._can_use_tool,
         }

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -12,12 +12,45 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
+# 装了 claude CLI 时共享用户自己的 ~/.claude；没装时内置 SDK agent（claude_agent_sdk
+# 捆绑 CLI）把家目录指到 DATA_DIR 下——Bosun 不在没装 claude 的机器上凭空创建
+# ~/.claude（用户反馈），也因此无须迁移登录凭证（macOS 凭证在 Keychain，不随目录走）。
 CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def claude_cli_installed() -> bool:
+    from . import config
+
+    binary = config.CLAUDE_BIN
+    if "/" in binary:
+        return Path(binary).expanduser().is_file()
+    return shutil.which(binary) is not None
+
+
+def claude_home() -> Path:
+    """内置 SDK agent 生效的 claude 家目录。"""
+    if claude_cli_installed():
+        return Path.home() / ".claude"
+    from . import config
+
+    return config.DATA_DIR / "claude-home"
+
+
+def claude_projects() -> Path:
+    return CLAUDE_PROJECTS if claude_cli_installed() else claude_home() / "projects"
+
+
+def claude_env_overrides() -> dict[str, str]:
+    """SDK 派发环境补丁：没装 claude CLI 时重定向捆绑 CLI 的家目录。"""
+    if claude_cli_installed():
+        return {}
+    return {"CLAUDE_CONFIG_DIR": str(claude_home())}
 CODEX_SESSIONS = Path.home() / ".codex" / "sessions"
 # omp 允许用 PI_CODING_AGENT_SESSION_DIR 改会话根目录；agent 是后端 spawn 的，
 # 继承的正是这份环境，所以这里读同一个变量才能跟它对上。
@@ -49,7 +82,7 @@ def encode_cwd(cwd: str) -> str:
 
 
 def cc_project_dir(cwd: str) -> Path:
-    return CLAUDE_PROJECTS / encode_cwd(cwd)
+    return claude_projects() / encode_cwd(cwd)
 
 
 def cc_session_path(cwd: str, uid: str) -> Path:


### PR DESCRIPTION
## 背景

方案①收尾（接 #8/#9）：没装 claude 的机器上，claude_agent_sdk 的捆绑 CLI 照样能跑内置 agent，但会把 `.claude.json`、`projects/`、`sessions/` 等全部写进凭空创建的 `~/.claude`（用户反馈的最后一块）。按拍板结论：**只按「装没装 CLI」分流，不做授权迁移**。

## 变更

- `sessions.claude_cli_installed()`：复用 `CLAUDE_BIN` 的解析结果探测 CLI 是否安装。
- `sessions.claude_home()` / `claude_env_overrides()`：装了 → 一切照旧共享 `~/.claude`（登录态、CLAUDE.md、配置不受影响，零迁移）；没装 → SDK 派发注入 `CLAUDE_CONFIG_DIR=~/.bosun/claude-home`，捆绑 CLI 的全部状态落在 Bosun 数据目录。
- transcript 捕获（`cc_project_dir`）与工作台「Claude 配置」页（`routers/claude.py`）同步跟随生效家目录，后者避免在没装 claude 的机器上经 UI 创建 `~/.claude`。
- codex/kimi/omp 无此问题：必须装了 CLI 才能跑，Bosun 已不写它们的家目录。

## 验证

- `backend/.venv/bin/python -m pytest tests/ -q` → **501 passed**（新增 test_claude_home_isolation 5 例：装/没装两种形态的家目录、SDK env 注入、捕获路径跟随、CLI 探测）。
- 开发中发现并修复一处测试逃逸：claude 资源页测试曾因 `_home()` 改动打到真实 `~/.claude`（已恢复现场），现测试显式钉住「已装 CLI」形态，重定向形态由新测试文件覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)