### PR TITLE
fix: 受控子任务的进程与线程泄漏（出结论不收进程 / 正常结束不级联 / spawn 无并发上限）

### DIFF
--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -551,6 +551,18 @@ def spawn_subtask(task_id: int, body: SpawnBody, request: Request = None):
     if engine not in ENGINES:
         raise HTTPException(400, f"未知引擎: {engine}")
 
+    # 名额在建行之前占：拿不到就直接回 429，不留一条起不来的子任务记录
+    if not subtasks.acquire_slot():
+        raise HTTPException(429, f"同时进行的子任务已达上限（{subtasks.concurrency()}），稍后再试")
+    try:
+        return _spawn_and_wait(parent, engine, body)
+    finally:
+        subtasks.release_slot()
+
+
+def _spawn_and_wait(parent, engine: str, body: SpawnBody) -> dict:
+    """建行、派发、阻塞等结论。调用方持有 spawn 名额。"""
+    task_id = parent["id"]
     title = (body.title or "").strip() or derive_title(body.prompt)
     child_id = db.execute(
         "INSERT INTO task(project_id,engine,prompt,title,priority,auto_approve,kind,status,"

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -239,6 +239,9 @@ def _on_exit(task_id: int, exit_code: int) -> None:
     if cur and cur["status"] == status:
         events.emit("task.status", {"task_id": task_id, "status": status, "exit_code": exit_code})
         threading.Thread(target=_finalize_tokens, args=(task_id, 3.0), daemon=True).start()
+    # 父任务进程退出同样要级联取消活动子任务：cancel/delete 有级联，但「跑完就退」
+    # 才是主流路径，漏掉它子任务就成了没人认领、也没人杀的孤儿进程。
+    _cancel_active_children(task_id)
     # 空出槽位，立即尝试拉起下一个
     tick()
 
@@ -496,6 +499,29 @@ def start_subtask(task_id: int) -> None:
         if task_id in _sessions:
             return
         _start_task(row)
+
+
+def finish_subtask(task_id: int) -> None:
+    """子任务出结论后收掉它的进程——一次性语义，等价于 `codex exec` 跑完即退。
+
+    不收就是主流路径漏进程：agent 按收尾约定回报后停在 waiting_input 等人核对，
+    进程（连同它自己起的 MCP 子进程）常驻不退，还一直被 _running_count 算作占槽。
+    父任务已经拿走结论，没人会再理它，也没有任何回收器管 waiting_input。
+
+    已出结论的落 done 而不是 cancelled：结论是有效的，看板和统计不该显示成被取消。
+    已是终态的（如 agent 回报 failed）只收进程，状态不动。
+    """
+    if task_id not in _sessions:
+        return
+    row = db.query_one("SELECT status FROM task WHERE id=?", (task_id,))
+    if row is not None and row["status"] == "waiting_input":
+        complete(task_id)  # graceful_stop 让引擎落盘会话，便于日后查阅/续跑
+        return
+    session = _sessions.pop(task_id, None)
+    if session is not None:
+        session.graceful_stop()
+        threading.Thread(target=_finalize_tokens, args=(task_id, 4.0), daemon=True).start()
+    tick()
 
 
 def _cancel_active_children(parent_id: int) -> None:

--- a/backend/app/subtasks.py
+++ b/backend/app/subtasks.py
@@ -14,6 +14,7 @@ agent 会绕开不用）。
 from __future__ import annotations
 
 import os
+import threading
 import time
 
 from . import db
@@ -23,6 +24,7 @@ _FALSE = {"0", "false", "no", "off"}
 DEFAULT_MAX_CHILDREN = 3      # 即最坏情况下的额度放大倍数，刻意取小
 DEFAULT_TIMEOUT = 900.0       # 15min，与 autopilot.FIX_TIMEOUT 同量级
 MAX_TIMEOUT = 3600.0          # 钳制上限：父任务不能被无限期阻塞
+DEFAULT_CONCURRENCY = 8       # 同时阻塞在 /spawn 上的请求数上限，见 acquire_slot
 _POLL_INTERVAL = 0.5
 
 # 子任务「已出结论」的状态。
@@ -34,6 +36,10 @@ _POLL_INTERVAL = 0.5
 # 授权提示上没人应答。判据取 report_result 是否落库——那是 agent 的权威回调。
 _TERMINAL_STATUSES = {"done", "failed", "cancelled", "interrupted"}
 FINISHED_STATUSES = _TERMINAL_STATUSES | {"waiting_input"}
+
+
+_inflight = 0
+_inflight_lock = threading.Lock()
 
 
 def _finished(status: str, report_result: str | None) -> bool:
@@ -71,6 +77,42 @@ def clamp_timeout(value: float) -> float:
     return min(max(seconds, 10.0), MAX_TIMEOUT)
 
 
+def concurrency() -> int:
+    """同时阻塞在 /spawn 上的请求数上限（默认 8）。"""
+    try:
+        return max(1, int(os.environ.get("BOSUN_SUBTASK_CONCURRENCY", DEFAULT_CONCURRENCY)))
+    except ValueError:
+        return DEFAULT_CONCURRENCY
+
+
+def acquire_slot() -> bool:
+    """占一个 spawn 名额；满了返回 False（调用方应回 429，而不是排队等）。
+
+    /spawn 是同步端点，一个请求会占住 anyio 线程池（默认 40 个线程）里的一个线程，
+    直到子任务出结论——最长 15 分钟。而 /report、/cancel 也都是同步端点、共用这个池：
+    不限流的话阻塞的 spawn 会把子任务自己的 /report 挤出线程池，子任务报不上结论、
+    父任务全部空转到超时，形成自锁。名额必须明显小于线程池容量。
+    「每父任务 3 个」管的是单个父任务的额度放大倍数，父任务数量本身没有上限，
+    拦不住这里的线程池耗尽。
+    """
+    global _inflight
+    with _inflight_lock:
+        if _inflight >= concurrency():
+            return False
+        _inflight += 1
+        return True
+
+
+def release_slot() -> None:
+    global _inflight
+    with _inflight_lock:
+        _inflight = max(0, _inflight - 1)
+
+
+def inflight() -> int:
+    return _inflight
+
+
 def child_count(parent_id: int) -> int:
     """该父任务已派生的子任务数（含已完成的：上限管的是总放大倍数，不是并发数）。"""
     row = db.query_one(
@@ -80,9 +122,11 @@ def child_count(parent_id: int) -> int:
 
 
 def wait_for_result(child_id: int, timeout: float) -> dict:
-    """阻塞等子任务出结论；超时则杀掉它并标记 timed_out。
+    """阻塞等子任务出结论；拿到结论就收掉它，超时则杀掉它并标记 timed_out。
 
-    超时必须杀：否则子任务会继续烧额度，而父任务已经不再关心它的结果。
+    两条路径都必须收进程，理由相同：父任务已经不再关心这个子任务了。
+    超时不杀会继续烧额度；出了结论不收则更隐蔽——agent 回报后停在 waiting_input，
+    进程常驻还占着槽（见 scheduler.finish_subtask）。
     """
     from . import scheduler  # 延迟导入：scheduler 依赖本模块，避免循环
 
@@ -94,8 +138,11 @@ def wait_for_result(child_id: int, timeout: float) -> dict:
         if row is None:  # 被删了，没有结论可等
             return {"status": "cancelled", "summary": "", "timed_out": False}
         if _finished(row["status"], row["report_result"]):
+            scheduler.finish_subtask(child_id)
+            # 收尾会把 waiting_input 落成 done，回报给 agent 的应是收尾后的终态
+            settled = db.query_one("SELECT status FROM task WHERE id=?", (child_id,))
             return {
-                "status": row["status"],
+                "status": settled["status"] if settled else row["status"],
                 "result": row["report_result"],
                 "summary": row["report_summary"] or "",
                 "timed_out": False,


### PR DESCRIPTION
## 背景

审查 e921c71（受控子任务）时发现的资源泄漏。该功能尚未在任何后端实例上跑过（现役进程起于 8/12 12:13，早于该 commit；本机 DB 里连 `parent_task_id` 列都还没有），所以线上没有存量影响。

## 改了什么

### 1. 出结论后收掉子任务进程（主流路径的泄漏）
`wait_for_result` 把 `waiting_input + report_result` 判为「已出结论」返回——这是收尾约定下的**正常终点**，但它只说明 agent 回报过，进程（连同它自己起的 MCP 子进程）还活着。而 `waiting_input` 是占槽状态，全仓也没有任何 `waiting_input` 回收器，于是每 spawn 一次就永久漏一个常驻 CLI 会话 + 一个 `max_concurrent` 槽。

新增 `scheduler.finish_subtask()`：出结论即收，语义对齐 `codex exec`（跑完即退）。走 `complete()` 而非 `cancel()`——`graceful_stop` 让引擎落盘会话，状态落 `done`，结论有效，统计不该显示成被取消；已是终态的（agent 回报 failed）只收进程、状态不动。

### 2. `_on_exit` 补上级联取消
原先只有 `cancel`/`delete` 级联，但父任务「跑完就退」才是主流路径，漏掉它子任务就成了没人认领也没人杀的孤儿——正是引入级联时想堵的那个洞。

### 3. `/spawn` 加同时在飞数上限（默认 8，`BOSUN_SUBTASK_CONCURRENCY`）
`/spawn` 是同步端点，一个请求占住 anyio 线程池（默认 40）一个线程最长 15min，而 `/report`、`/cancel` 同样是同步端点、共用这个池。不限流时阻塞的 spawn 会把子任务自己的 `/report` 挤出线程池 → 子任务报不上结论 → 父任务全部空转到超时，形成自锁。原有的「每父任务 3 个」管的是单父任务额度放大倍数，父任务数量本身没上限，拦不住线程池耗尽。名额在建行前占，拿不到直接 429；`try/finally` 释放，子任务抛异常也不会锁死闸门。

## 验证

红灯先行——新增 10 条用例在改动前的代码上全红，且红在预期原因上：

```
FAILED FinishSubtaskTest::test_conclusion_stops_the_child_process - 子任务进程没被收掉，会常驻并一直占槽
FAILED FinishSubtaskTest::test_settled_child_is_done_not_cancelled - 'waiting_input' != 'done'
FAILED CascadeCancelTest::test_parent_process_exit_cancels_active_children - 'running' != 'cancelled'
（其余 7 条为新 API 尚不存在的 AttributeError）
10 failed, 24 passed
```

改后：

```
tests/test_subtasks.py  34 passed
tests（全量）           603 passed, 3 failed
```

全量的 3 条失败与本 PR 无关：2 条 `test_report_header_literal` 属另一个 CLI 正在飞的 `directives.py` 改动（在主工作区绿）、1 条 `test_runtime_config::QuotaUsageTest` 在改动前的 main 上同样红（预存）。

注：`tests/` 与 `docs/` 在本仓 `.gitignore` 内（本地不入库），故本 PR 只含 backend 三个文件；对应的 10 条用例与 spec 更新在本地工作区。