### PR TITLE
fix: 支持父子任务多轮双向通信

### DIFF
--- a/backend/app/directives.py
+++ b/backend/app/directives.py
@@ -59,11 +59,17 @@ SUBTASK_TEMPLATE = (
     "\n\n---\n"
     "[Bosun 环境] 需要另一个模型出第二意见/交叉复审时，**优先用下面这条派生子任务**，"
     "不要自己在终端里直接起别的 CLI——直接起的那个 Bosun 看不见、管不了、也不计额度。"
-    "可用引擎：{engines}。命令会阻塞到子任务出结论并把结论打印出来：\n"
+    "可用引擎：{engines}。命令会阻塞到子任务本轮回报并把内容打印出来：\n"
     "curl -sS -X POST -H 'Content-Type: application/json' "
     '-H "Authorization: Bearer $BOSUN_TASK_TOKEN" '
     '-d "{{\\"engine\\":\\"<引擎>\\",\\"prompt\\":\\"<要它做什么>\\"}}" '
     '"$BOSUN_API/api/tasks/$BOSUN_TASK_ID/spawn"\n'
+    "若返回 `needs_reply:true`，读取其中的 `id` 和 `summary`，决定后用父任务同一凭证回复：\n"
+    "curl -sS -X POST -H 'Content-Type: application/json' "
+    '-H "Authorization: Bearer $BOSUN_TASK_TOKEN" '
+    '-d "{{\\"message\\":\\"<回复内容>\\"}}" '
+    '"$BOSUN_API/api/tasks/<子任务id>/reply"\n'
+    "可重复回复，直到返回最终结论。"
     "（默认最多 3 个子任务、单个最长 15 分钟；子任务不能再派生子任务。"
     "**本轮的收尾回报仍由你自己发**，子任务的回报只属于它自己。）"
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -73,7 +73,7 @@ app = FastAPI(title="Bosun")
 _PUBLIC_API_PATHS = {"/api/health", "/api/auth/status", "/api/auth/login"}
 
 # agent 回调端点不走会话 token(agent 登录不了)，改由各端点自己校验任务级凭证。
-_TASK_CREDENTIAL_PATH = re.compile(r"^/api/tasks/\d+/(?:report|spawn|result)$")
+_TASK_CREDENTIAL_PATH = re.compile(r"^/api/tasks/\d+/(?:report|spawn|result|reply)$")
 
 
 @app.middleware("http")

--- a/backend/app/pty_session.py
+++ b/backend/app/pty_session.py
@@ -788,6 +788,12 @@ class PtySession:
             self._nudge_sent = False  # 新一轮重新获得一次催报机会
             self._set_status("running")
 
+    def submit_message(self, message: str) -> None:
+        """安全提交完整消息；括号粘贴避免多行内容被 PTY 逐行执行。"""
+        if self.proc is None or not self.proc.isalive():
+            return
+        self.write(f"\x1b[200~{message}\x1b[201~\r")
+
     def resize(self, rows: int, cols: int) -> None:
         if self.proc is not None and self.proc.isalive():
             try:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -539,6 +539,11 @@ class SpawnBody(BaseModel):
     timeout: float | None = None
 
 
+class SubtaskReplyBody(BaseModel):
+    message: str
+    timeout: float | None = None
+
+
 def _spawn_authorized(parent_id: int, request: Request | None) -> bool:
     """派生子任务只认父任务**自己**的回调凭证。
 
@@ -617,6 +622,53 @@ def _spawn_and_wait(parent, engine: str, body: SpawnBody) -> dict:
     return {"id": child_id, "engine": engine, **result}
 
 
+@router.post("/{task_id}/reply")
+def reply_to_subtask(task_id: int, body: SubtaskReplyBody, request: Request = None):
+    """父任务回复子任务的提问，并同步等待子任务下一轮回报。"""
+    child = db.query_one("SELECT * FROM task WHERE id=? AND deleted=0", (task_id,))
+    if child is None:
+        raise HTTPException(404, "子任务不存在")
+    parent_id = child["parent_task_id"]
+    if parent_id is None:
+        raise HTTPException(409, "目标任务不是子任务")
+    if not _spawn_authorized(parent_id, request):
+        raise HTTPException(401, "父任务凭证无效")
+    parent = db.query_one("SELECT status FROM task WHERE id=? AND deleted=0", (parent_id,))
+    if parent is None or parent["status"] not in ("running", "waiting_input"):
+        raise HTTPException(409, "父任务未在执行，不能继续子任务通信")
+    if child["status"] != "waiting_input" or child["report_result"] != "needs_input":
+        raise HTTPException(409, "子任务当前未等待父任务回复")
+    message = body.message.strip()
+    if not message:
+        raise HTTPException(400, "回复内容不能为空")
+    if scheduler.get_session(task_id) is None:
+        raise HTTPException(409, "子任务会话已结束，无法回复")
+    if not subtasks.acquire_slot():
+        raise HTTPException(429, f"同时进行的子任务通信已达上限（{subtasks.concurrency()}），稍后再试")
+    try:
+        # 必须先清上一轮回报再投递；反过来会有竞态，可能擦掉子任务极速返回的新回报。
+        db.execute(
+            "UPDATE task SET status='running', report_result=NULL, report_summary=NULL, "
+            "waiting_since=NULL WHERE id=?",
+            (task_id,),
+        )
+        if not scheduler.send_subtask_reply(task_id, message):
+            db.execute(
+                "UPDATE task SET status='waiting_input', report_result='needs_input', "
+                "report_summary=?, waiting_since=? WHERE id=?",
+                (child["report_summary"], child["waiting_since"], task_id),
+            )
+            raise HTTPException(409, "子任务会话已结束，无法回复")
+        events.emit("task.status", {"task_id": task_id, "status": "running"})
+        timeout = subtasks.clamp_timeout(
+            body.timeout if body.timeout is not None else subtasks.default_timeout()
+        )
+        result = subtasks.wait_for_result(task_id, timeout)
+        return {"id": task_id, "engine": child["engine"], **result}
+    finally:
+        subtasks.release_slot()
+
+
 @router.get("/{task_id}/result")
 def get_task_result(task_id: int, request: Request = None):
     """补查子任务结论（/spawn 因超时或连接中断没拿到时的兜底）。
@@ -637,7 +689,8 @@ def get_task_result(task_id: int, request: Request = None):
         "status": row["status"],
         "result": row["report_result"],
         "summary": row["report_summary"] or "",
-        "finished": subtasks._finished(row["status"], row["report_result"]),
+        "needs_reply": row["report_result"] == "needs_input",
+        "finished": subtasks.is_final(row["status"], row["report_result"]),
     }
 
 

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -539,6 +539,21 @@ def finish_subtask(task_id: int) -> None:
     tick()
 
 
+def send_subtask_reply(task_id: int, message: str) -> bool:
+    """把父任务的回复作为新一轮用户消息投递给仍存活的子任务会话。"""
+    session = _sessions.get(task_id)
+    if session is None or not session.is_alive():
+        return False
+    submit = getattr(session, "submit_message", None)
+    if submit is None:
+        return False
+    try:
+        submit(message)
+    except Exception:  # 会话可能恰在投递时退出；调用方会保留上一轮问题供重试
+        return False
+    return True
+
+
 def _cancel_active_children(parent_id: int) -> None:
     """父任务终止时级联取消仍在跑的子任务。
 

--- a/backend/app/sdk_session.py
+++ b/backend/app/sdk_session.py
@@ -261,6 +261,16 @@ class SdkSession:
             self._event({"t": "user", "text": text})  # 落库+回放: 转录含用户输入
             self._sdk_loop.call_soon_threadsafe(self._input_q.put_nowait, text)
 
+    def submit_message(self, message: str) -> None:
+        """提交一条完整的新回合消息（HTTP 父子通信与终端输入共用）。"""
+        text = message.strip()
+        if not text or not self._sdk_loop or not self._input_q:
+            return
+        self._reported = False
+        self._event({"t": "user", "text": text})
+        self._sdk_loop.call_soon_threadsafe(self._input_q.put_nowait, text)
+        self._set_status("running")
+
     def resize(self, rows: int, cols: int) -> None:
         pass
 

--- a/backend/app/subtasks.py
+++ b/backend/app/subtasks.py
@@ -48,6 +48,13 @@ def _finished(status: str, report_result: str | None) -> bool:
     return status == "waiting_input" and bool(report_result)
 
 
+def is_final(status: str, report_result: str | None) -> bool:
+    """是否已得到最终结果；needs_input 只结束当前通信回合。"""
+    return status in _TERMINAL_STATUSES or (
+        status == "waiting_input" and report_result == "done"
+    )
+
+
 def enabled() -> bool:
     """子任务总开关（默认开）。BOSUN_SUBTASK=0 关闭。"""
     return os.environ.get("BOSUN_SUBTASK", "1").strip().lower() not in _FALSE
@@ -122,11 +129,11 @@ def child_count(parent_id: int) -> int:
 
 
 def wait_for_result(child_id: int, timeout: float) -> dict:
-    """阻塞等子任务出结论；拿到结论就收掉它，超时则杀掉它并标记 timed_out。
+    """阻塞等子任务本轮回报；最终结论收进程，提问则保留会话等待父任务回复。
 
-    两条路径都必须收进程，理由相同：父任务已经不再关心这个子任务了。
-    超时不杀会继续烧额度；出了结论不收则更隐蔽——agent 回报后停在 waiting_input，
-    进程常驻还占着槽（见 scheduler.finish_subtask）。
+    最终结论与超时必须收进程：超时不杀会继续烧额度；最终结论不收则更隐蔽——
+    agent 回报后停在 waiting_input，进程常驻还占着槽（见 scheduler.finish_subtask）。
+    needs_input 是例外：父任务仍要向这个会话回复，不能提前回收。
     """
     from . import scheduler  # 延迟导入：scheduler 依赖本模块，避免循环
 
@@ -136,15 +143,24 @@ def wait_for_result(child_id: int, timeout: float) -> dict:
             "SELECT status, report_result, report_summary FROM task WHERE id=?", (child_id,)
         )
         if row is None:  # 被删了，没有结论可等
-            return {"status": "cancelled", "summary": "", "timed_out": False}
+            return {
+                "status": "cancelled", "result": None, "summary": "",
+                "needs_reply": False, "timed_out": False,
+            }
         if _finished(row["status"], row["report_result"]):
-            scheduler.finish_subtask(child_id)
+            needs_reply = row["report_result"] == "needs_input"
+            if not needs_reply:
+                scheduler.finish_subtask(child_id)
             # 收尾会把 waiting_input 落成 done，回报给 agent 的应是收尾后的终态
             settled = db.query_one("SELECT status FROM task WHERE id=?", (child_id,))
             return {
-                "status": settled["status"] if settled else row["status"],
+                "status": (
+                    row["status"] if needs_reply
+                    else settled["status"] if settled else row["status"]
+                ),
                 "result": row["report_result"],
                 "summary": row["report_summary"] or "",
+                "needs_reply": needs_reply,
                 "timed_out": False,
             }
         if time.time() >= deadline:
@@ -153,6 +169,7 @@ def wait_for_result(child_id: int, timeout: float) -> dict:
                 "status": "cancelled",
                 "result": None,
                 "summary": f"子任务超时({int(timeout)}s)未出结论，已终止",
+                "needs_reply": False,
                 "timed_out": True,
             }
         time.sleep(_POLL_INTERVAL)

--- a/backend/tests/test_subtask_communication.py
+++ b/backend/tests/test_subtask_communication.py
@@ -1,0 +1,209 @@
+import sqlite3
+import time
+import unittest
+from unittest.mock import patch
+
+from app import auth, db, scheduler, subtasks
+from app.main import _TASK_CREDENTIAL_PATH
+from app.pty_session import PtySession
+from app.routers import tasks as tasks_router
+from app.sdk_session import SdkSession
+
+
+class _Request:
+    def __init__(self, token):
+        self.headers = {"authorization": f"Bearer {token}"}
+
+
+class SubtaskCommunicationTest(unittest.TestCase):
+    def setUp(self):
+        self.old_connection = db._conn
+        self.connection = sqlite3.connect(":memory:", check_same_thread=False)
+        self.connection.row_factory = sqlite3.Row
+        self.connection.execute("PRAGMA foreign_keys=ON")
+        db._conn = self.connection
+        db.init_db()
+        db.execute(
+            "INSERT INTO project(id,name,path,created_at) VALUES(1,'p','/tmp/p',?)",
+            (time.time(),),
+        )
+        self.parent_id = self._task("running")
+        self.parent_token = auth.issue_task_token(self.parent_id)
+
+    def tearDown(self):
+        db._conn = self.old_connection
+        self.connection.close()
+        while subtasks.inflight():
+            subtasks.release_slot()
+
+    def _task(self, status, parent_id=None):
+        return db.execute(
+            "INSERT INTO task(project_id,engine,prompt,status,parent_task_id,created_at) "
+            "VALUES(1,'cc','任务',?,?,?)",
+            (status, parent_id, time.time()),
+        )
+
+    def _waiting_child(self):
+        child_id = self._task("waiting_input", self.parent_id)
+        db.execute(
+            "UPDATE task SET report_result='needs_input', report_summary='选 A 还是 B？' "
+            "WHERE id=?",
+            (child_id,),
+        )
+        return child_id
+
+    def test_needs_input_keeps_child_alive_for_parent_reply(self):
+        child_id = self._waiting_child()
+        with patch.object(scheduler, "finish_subtask") as finish:
+            result = subtasks.wait_for_result(child_id, 1.0)
+
+        finish.assert_not_called()
+        self.assertTrue(result["needs_reply"])
+        self.assertFalse(subtasks.is_final(result["status"], result["result"]))
+
+    def test_parent_can_reply_and_receive_the_next_child_report(self):
+        child_id = self._waiting_child()
+        delivered = []
+
+        def deliver(task_id, message):
+            delivered.append((task_id, message))
+            return True
+
+        with patch.object(scheduler, "get_session", return_value=object()), patch.object(
+            scheduler, "send_subtask_reply", side_effect=deliver
+        ), patch.object(
+            subtasks,
+            "wait_for_result",
+            return_value={
+                "status": "done", "result": "done", "summary": "完成",
+                "needs_reply": False, "timed_out": False,
+            },
+        ):
+            result = tasks_router.reply_to_subtask(
+                child_id,
+                tasks_router.SubtaskReplyBody(message="选 A，继续"),
+                _Request(self.parent_token),
+            )
+
+        self.assertEqual(delivered, [(child_id, "选 A，继续")])
+        self.assertEqual(result["summary"], "完成")
+        row = db.query_one("SELECT report_result, report_summary FROM task WHERE id=?", (child_id,))
+        self.assertIsNone(row["report_result"])
+        self.assertIsNone(row["report_summary"])
+
+    def test_child_token_cannot_reply_as_parent(self):
+        child_id = self._waiting_child()
+        child_token = auth.issue_task_token(child_id)
+        auth.set_password("test-password")
+        try:
+            with self.assertRaises(tasks_router.HTTPException) as raised:
+                tasks_router.reply_to_subtask(
+                    child_id,
+                    tasks_router.SubtaskReplyBody(message="冒充父任务"),
+                    _Request(child_token),
+                )
+        finally:
+            auth.clear_password()
+
+        self.assertEqual(raised.exception.status_code, 401)
+
+    def test_failed_delivery_preserves_the_child_question(self):
+        child_id = self._waiting_child()
+        with patch.object(scheduler, "get_session", return_value=object()), patch.object(
+            scheduler, "send_subtask_reply", return_value=False
+        ):
+            with self.assertRaises(tasks_router.HTTPException) as raised:
+                tasks_router.reply_to_subtask(
+                    child_id,
+                    tasks_router.SubtaskReplyBody(message="选 A"),
+                    _Request(self.parent_token),
+                )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        row = db.query_one(
+            "SELECT status, report_result, report_summary FROM task WHERE id=?", (child_id,)
+        )
+        self.assertEqual(row["status"], "waiting_input")
+        self.assertEqual(row["report_result"], "needs_input")
+        self.assertEqual(row["report_summary"], "选 A 还是 B？")
+
+    def test_reply_endpoint_uses_task_credentials(self):
+        self.assertTrue(_TASK_CREDENTIAL_PATH.fullmatch("/api/tasks/42/reply"))
+
+    def test_completed_parent_cannot_keep_driving_child(self):
+        child_id = self._waiting_child()
+        db.execute("UPDATE task SET status='done' WHERE id=?", (self.parent_id,))
+
+        with self.assertRaises(tasks_router.HTTPException) as raised:
+            tasks_router.reply_to_subtask(
+                child_id,
+                tasks_router.SubtaskReplyBody(message="继续"),
+                _Request(self.parent_token),
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+
+
+class SessionMessageDeliveryTest(unittest.TestCase):
+    class _Loop:
+        def call_soon_threadsafe(self, function, *args):
+            function(*args)
+
+    def test_pty_multiline_message_is_submitted_as_one_bracketed_paste(self):
+        writes = []
+
+        class _Process:
+            def isalive(self):
+                return True
+
+            def write(self, data):
+                writes.append(data)
+
+        session = PtySession.__new__(PtySession)
+        session.proc = _Process()
+        session.loop = self._Loop()
+        session.task_id = 1
+        session.on_status = lambda *args: None
+        session.status = "waiting_input"
+        session._reported = True
+        session._wait_reason = "reported"
+        session._waiting_kind = "review"
+        session._buf = ""
+        session._nudge_sent = True
+        session.last_output = 0.0
+
+        session.submit_message("第一行\n第二行")
+
+        self.assertEqual(
+            writes,
+            [b"\x1b[200~\xe7\xac\xac\xe4\xb8\x80\xe8\xa1\x8c\n\xe7\xac\xac\xe4\xba\x8c\xe8\xa1\x8c\x1b[201~\r"],
+        )
+        self.assertFalse(session._reported)
+        self.assertEqual(session.status, "running")
+
+    def test_sdk_message_starts_the_next_turn(self):
+        queued = []
+
+        class _Queue:
+            def put_nowait(self, item):
+                queued.append(item)
+
+        session = SdkSession.__new__(SdkSession)
+        session.status = "waiting_input"
+        session._reported = True
+        session._sdk_loop = self._Loop()
+        session._input_q = _Queue()
+        session.loop = self._Loop()
+        session.task_id = 1
+        session.on_status = lambda *args: None
+        session._event = lambda event: None
+
+        session.submit_message("选 A\n继续")
+
+        self.assertEqual(queued, ["选 A\n继续"])
+        self.assertFalse(session._reported)
+        self.assertEqual(session.status, "running")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更摘要

- 子任务回报 `needs_input` 时保留活会话，不再当作最终结论回收
- 新增父任务凭证保护的 `/api/tasks/{child_id}/reply`，支持多轮同步问答
- 为 PTY 和 SDK 会话增加完整消息投递，并覆盖并发、失败回滚和父任务生命周期
- 更新 agent 派生提示，自动说明回复方式

## 验证

- `PYTHONPATH=backend backend/.venv/bin/python -m unittest discover -s backend/tests -p 'test_*.py'`：26 项通过\n- `backend/.venv/bin/python -m unittest tests.test_subtasks tests.test_task_report tests.test_pty_session tests.test_report_auth tests.test_engine_roster_hint`：131 项通过\n- `git diff --check`：通过