### PR TITLE
feat: add quota protection toggle

### DIFF
--- a/backend/app/quota.py
+++ b/backend/app/quota.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import certifi
 
-from . import config
+from . import config, db
 from .env import child_env
 
 _SSL_CTX = ssl.create_default_context(cafile=certifi.where())
@@ -226,12 +226,15 @@ def _cached(provider: str, min_interval: int, fetch, refresh: bool = False) -> d
 
 
 def block_pct() -> int:
-    from . import db
-
     try:
         return int(db.get_setting("quota_block_pct", 90))
     except (TypeError, ValueError):
         return 90
+
+
+def is_enabled() -> bool:
+    value = db.get_setting("quota_enabled", "1")
+    return str(value).strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _provider_usage(provider: str, refresh: bool = False) -> dict:
@@ -246,16 +249,23 @@ def get_usage(engine: str | None = None, refresh: bool = False) -> dict:
     if engine:
         provider = _ENGINE_PROVIDER.get(engine)
         if provider:
-            return {provider: _provider_usage(provider, refresh), "block_pct": block_pct()}
+            return {
+                provider: _provider_usage(provider, refresh),
+                "block_pct": block_pct(),
+                "enabled": is_enabled(),
+            }
     return {
         "claude": _provider_usage("claude", refresh),
         "codex": _provider_usage("codex", refresh),
         "block_pct": block_pct(),
+        "enabled": is_enabled(),
     }
 
 
 def check_engine(engine: str) -> tuple[bool, float | None, str]:
     """返回 (是否可执行, 最高窗口用量%, 原因)。用量拿不到时放行(不拦)。"""
+    if not is_enabled():
+        return True, None, "额度保护已关闭，放行"
     provider = _ENGINE_PROVIDER.get(engine)
     usage = _provider_usage(provider) if provider else None
     if not usage or not usage.get("available"):

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel
 
-from .. import browser_computer, backend_control, config, db, engine_models, engine_settings, log_archive, scheduler
+from .. import browser_computer, backend_control, config, db, engine_models, engine_settings, log_archive, quota, scheduler
 from ..pty_session import script_log_path_for
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
@@ -15,6 +15,7 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 
 class Settings(BaseModel):
     max_concurrent: int
+    quota_enabled: bool = True
     claude_invocation: str = "auto"
     claude_model: str = ""
     claude_effort: str = ""
@@ -29,6 +30,7 @@ class Settings(BaseModel):
 def get_settings():
     return {
         "max_concurrent": int(db.get_setting("max_concurrent", 3)),
+        "quota_enabled": quota.is_enabled(),
         "claude_invocation": engine_settings.claude_invocation(),
         "claude_model": engine_settings.claude_model(),
         "claude_model_options": engine_settings.claude_model_options(),
@@ -155,6 +157,7 @@ def restart_backend(background_tasks: BackgroundTasks):
 @router.put("")
 def update_settings(body: Settings):
     db.set_setting("max_concurrent", max(1, body.max_concurrent))
+    db.set_setting("quota_enabled", "1" if body.quota_enabled else "0")
     invocation = body.claude_invocation.strip().lower()
     if invocation not in engine_settings.CLAUDE_INVOCATIONS:
         invocation = "auto"

--- a/backend/tests/test_quota_toggle.py
+++ b/backend/tests/test_quota_toggle.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import patch
+
+from backend.app import quota
+from backend.app.routers import settings
+
+
+class QuotaToggleTest(unittest.TestCase):
+    def test_quota_protection_is_enabled_by_default(self):
+        with patch.object(quota.db, "get_setting", return_value=None):
+            self.assertTrue(quota.is_enabled())
+
+    def test_disabled_quota_protection_bypasses_usage_check(self):
+        with (
+            patch.object(quota, "is_enabled", return_value=False),
+            patch.object(quota, "_provider_usage") as provider_usage,
+        ):
+            self.assertEqual(quota.check_engine("cc"), (True, None, "额度保护已关闭，放行"))
+
+        provider_usage.assert_not_called()
+
+    def test_settings_persist_quota_toggle(self):
+        stored = {}
+
+        def get_setting(key, default=None):
+            return stored.get(key, default)
+
+        with (
+            patch.object(settings.db, "get_setting", side_effect=get_setting),
+            patch.object(settings.db, "set_setting", side_effect=lambda key, value: stored.__setitem__(key, value)),
+            patch.object(settings.scheduler, "tick"),
+            patch.object(settings.browser_computer, "availability", return_value={}),
+        ):
+            result = settings.update_settings(settings.Settings(max_concurrent=3, quota_enabled=False))
+
+        self.assertEqual(stored["quota_enabled"], "0")
+        self.assertFalse(result["quota_enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const DEFAULT_AUTH: AuthStatus = {
 };
 const DEFAULT_SETTINGS: AppSettings = {
   max_concurrent: 3,
+  quota_enabled: true,
   claude_invocation: "auto",
   claude_model: "",
   claude_model_options: [{ value: "", label: "默认" }],

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ import type { Engine, Finding, IssueSource, LocalSession, Project, Task } from "
 
 export type AppSettings = {
   max_concurrent: number;
+  quota_enabled: boolean;
   claude_invocation: "auto" | "sdk" | "cli";
   claude_model: string;
   claude_model_options: { value: string; label: string }[];

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -888,7 +888,7 @@ export function SettingsView({
       </SettingsGroup>
 
       <SettingsGroup label="运行与系统">
-        <Section title="运行" hint="控制同时执行的任务数量。">
+        <Section title="运行" hint="控制任务并发与额度保护。">
           <Field label="并发上限">
             <input
               type="number"
@@ -897,6 +897,19 @@ export function SettingsView({
               value={settings.max_concurrent}
               onChange={(e) => void onChange({ max_concurrent: Number(e.target.value) })}
             />
+          </Field>
+          <Field
+            label="用量额度保护"
+            hint="默认开启；如不需要 Bosun 按用量阈值拦截任务，可在此关闭。"
+          >
+            <label className="flex items-center gap-2 text-sm text-dh-tsoft">
+              <input
+                type="checkbox"
+                checked={settings.quota_enabled}
+                onChange={(e) => void onChange({ quota_enabled: e.target.checked })}
+              />
+              {settings.quota_enabled ? "已开启" : "已关闭"}
+            </label>
           </Field>
         </Section>
         <Section title="系统" hint="管理由 Bosun.app 托管的后端服务。">

--- a/frontend/src/quota.ts
+++ b/frontend/src/quota.ts
@@ -7,6 +7,7 @@ export async function guardQuota(engine?: string): Promise<boolean> {
   if (engine === "omp" || engine === "kimi" || engine === "browser") return true;
   try {
     const q = await api.quota(engine);
+    if (q.enabled === false) return true;
     const limit = q.block_pct ?? 90;
     const list = engine
       ? [{ name: engine === "cc" ? "Claude" : "Codex", ...(engine === "cc" ? q.claude : q.codex) }]


### PR DESCRIPTION
## 变更摘要
- 设置页新增“用量额度保护”开关，默认开启，并提示可关闭
- 关闭后保留额度展示，但跳过前端确认与后端额度拦截
- 新增默认值、关闭放行、设置持久化回归测试

## 验证
- `python3 -m unittest backend.tests.test_quota_toggle`：3/3 通过
- `npm run build`：通过（Vite 924 modules transformed）
- 隔离 API：首次 GET `quota_enabled=true`；PUT false 后再次 GET 仍为 false
- `git diff --cached --check`：通过

## 已知限制
- Browser 插件未提供，仓库也未安装 Playwright；未执行真实浏览器截图/点击验收
- 关联后端套件 20 个通过，Browser 用例 1 个因本机缺 Python Playwright 未执行