### PR TITLE
feat: OpenAI API Key 可在设置页配置，设置页改为宽屏多列布局

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,13 @@ pkill -x Bosun; rm -rf /Applications/Bosun.app
 
 Browser 是独立的任务引擎，用于验收本机正在运行的 Web 应用。任务指令必须包含 `http://localhost:端口`、`http://127.0.0.1:端口` 或其它回环地址；公网、局域网地址、文件上传下载、剪贴板和非 HTTP(S) 导航均会被阻止。提交、删除、支付、敏感字段填写等动作会暂停并等待人工确认。
 
-源码运行时安装 Chromium 并提供 OpenAI API Key：
+源码运行时安装 Chromium：
 
 ```bash
 backend/.venv/bin/python -m playwright install chromium
-export BOSUN_OPENAI_API_KEY="..."
 ```
+
+OpenAI API Key 直接在「设置 → Browser Computer Use → API Key」里填写（保存在本机数据库）；也可继续用 `BOSUN_OPENAI_API_KEY` / `OPENAI_API_KEY` 环境变量，设置页填写的优先。
 
 设置页显示 Browser「就绪」后，新建任务时才会出现该选项。MVP 默认使用 `gpt-5.6`，可用 `BOSUN_COMPUTER_MODEL` 覆盖；它不参与自动选引擎、Autopilot、子任务或 CLI 会话接续。二进制发行包会包含 Playwright 运行库，但 Chromium 仍需在运行机器上安装。
 
@@ -198,7 +199,7 @@ export BOSUN_OPENAI_API_KEY="..."
 | `BOSUN_CODEX_BIN` | 自动探测 `codex` | Codex CLI 可执行文件路径 |
 | `BOSUN_OMP_BIN` | 自动探测 `omp` | Oh My Pi 可执行文件路径 |
 | `BOSUN_KIMI_BIN` | 自动探测 `kimi` | Kimi Code CLI 可执行文件路径 |
-| `BOSUN_OPENAI_API_KEY` | 未设置 | Browser Computer Use 使用的 OpenAI API Key（也兼容 `OPENAI_API_KEY`） |
+| `BOSUN_OPENAI_API_KEY` | 未设置 | Browser Computer Use / 语音转写使用的 OpenAI API Key（也兼容 `OPENAI_API_KEY`）；设置页填写的优先 |
 | `BOSUN_COMPUTER_MODEL` | `gpt-5.6` | Browser Computer Use 模型 |
 | `BOSUN_COMPUTER_TIMEOUT` | `300` | 单个 Browser 任务最长运行秒数 |
 | `BOSUN_COMPUTER_MAX_ACTIONS` | `100` | 单个 Browser 任务最多执行的浏览器动作数 |

--- a/backend/app/browser_computer.py
+++ b/backend/app/browser_computer.py
@@ -13,12 +13,14 @@ import os
 import re
 import shutil
 import socket
+import sqlite3
 import threading
 import time
 from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlsplit
 
+from . import db
 from .config import DATA_DIR
 from .pty_session import TerminalBacklog, _put_drop
 
@@ -245,6 +247,45 @@ async def risky_action_reason(page: Any, action: Any) -> str | None:
     return None
 
 
+API_KEY_SETTING = "browser_openai_api_key"
+
+
+def resolve_api_key() -> tuple[str, str]:
+    """返回 (key, 来源)：设置页填写的优先，其次环境变量（兼容旧部署），都没有则为空。
+
+    来源取值 "settings" / "env" / ""。
+    """
+    try:
+        stored = str(db.get_setting(API_KEY_SETTING, "") or "").strip()
+    except sqlite3.Error:
+        stored = ""  # 数据库尚未就绪（如启动早期）时退回环境变量，不阻塞可用性探测
+    if stored:
+        return stored, "settings"
+    for name in ("BOSUN_OPENAI_API_KEY", "OPENAI_API_KEY"):
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value, "env"
+    return "", ""
+
+
+def api_key() -> str:
+    return resolve_api_key()[0]
+
+
+def mask_api_key(key: str) -> str:
+    """只回前端掩码，明文永不出后端。"""
+    if not key:
+        return ""
+    return f"{key[:3]}…{key[-4:]}" if len(key) > 8 else "已配置"
+
+
+def invalidate_availability() -> None:
+    """改动 Key 后立即失效可用性缓存，免得设置页还显示旧状态。"""
+    global _availability_cache
+    with _availability_lock:
+        _availability_cache = None
+
+
 def availability() -> dict[str, Any]:
     """Return a user-facing readiness result without launching a browser."""
     global _availability_cache
@@ -253,8 +294,9 @@ def availability() -> dict[str, Any]:
         if _availability_cache and now - _availability_cache[0] < _AVAILABILITY_TTL:
             return dict(_availability_cache[1])
         missing: list[str] = []
-        if not (os.environ.get("BOSUN_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")):
-            missing.append("未配置 BOSUN_OPENAI_API_KEY 或 OPENAI_API_KEY")
+        key, key_source = resolve_api_key()
+        if not key:
+            missing.append("未配置 OpenAI API Key（可在下方填写，或设置 BOSUN_OPENAI_API_KEY 环境变量）")
         try:
             from playwright.sync_api import sync_playwright
 
@@ -265,7 +307,13 @@ def availability() -> dict[str, Any]:
             missing.append("未安装 Playwright Python 包")
         except Exception as exc:  # noqa: BLE001
             missing.append(f"Playwright Chromium 检测失败：{exc}")
-        result = {"available": not missing, "missing": missing, "model": computer_model()}
+        result = {
+            "available": not missing,
+            "missing": missing,
+            "model": computer_model(),
+            "api_key_source": key_source,
+            "api_key_hint": mask_api_key(key),
+        }
         _availability_cache = (now, result)
         return dict(result)
 
@@ -373,8 +421,8 @@ class BrowserSession:
         from openai import AsyncOpenAI
         from playwright.async_api import async_playwright
 
-        api_key = os.environ.get("BOSUN_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
-        client = self._client_factory(api_key) if self._client_factory else AsyncOpenAI(api_key=api_key)
+        key = api_key()
+        client = self._client_factory(key) if self._client_factory else AsyncOpenAI(api_key=key)
         run_dir = DATA_DIR / "browser-runs" / str(self.task_id)
         run_dir.mkdir(parents=True, exist_ok=True)
 

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -29,6 +29,8 @@ class Settings(BaseModel):
     omp_model: str = ""
     omp_thinking: str = ""
     kimi_model: str = ""
+    # None = 本次不改动（前端保存其它设置时不必回传密钥）；"" = 清除
+    browser_api_key: str | None = None
 
 
 def status_badge_enabled() -> bool:
@@ -199,6 +201,9 @@ def update_settings(body: Settings):
     db.set_setting("omp_model", engine_settings.normalize_omp_model(body.omp_model))
     db.set_setting("omp_thinking", engine_settings.normalize_omp_thinking(body.omp_thinking))
     db.set_setting("kimi_model", engine_settings.normalize_kimi_model(body.kimi_model))
+    if body.browser_api_key is not None:
+        db.set_setting(browser_computer.API_KEY_SETTING, body.browser_api_key.strip())
+        browser_computer.invalidate_availability()
     for engine, old_root in old_roots.items():
         agent_skills.migrate_managed_skills(engine, old_root, agent_skills.skills_dir(engine))
     agent_skills.sync_installed_engines()

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -841,9 +841,9 @@ async def transcribe_audio(task_id: int, file: UploadFile = File(...)):
     if db.query_one("SELECT id FROM task WHERE id=?", (task_id,)) is None:
         raise HTTPException(404, "任务不存在")
 
-    api_key = os.environ.get("BOSUN_OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    api_key = browser_computer.api_key()
     if not api_key:
-        raise HTTPException(400, "未配置 OPENAI_API_KEY 或 BOSUN_OPENAI_API_KEY，无法语音转文字")
+        raise HTTPException(400, "未配置 OpenAI API Key，无法语音转文字（可在设置页填写）")
 
     data = await file.read(MAX_AUDIO_BYTES + 1)
     if not data:

--- a/backend/tests/test_browser_api_key.py
+++ b/backend/tests/test_browser_api_key.py
@@ -1,0 +1,84 @@
+"""Browser Computer Use 的 OpenAI Key 可在设置页配置（环境变量退化为回退项）。"""
+import unittest
+from unittest.mock import patch
+
+from app import browser_computer
+from app.routers import settings
+
+
+class ResolveApiKeyTest(unittest.TestCase):
+    def test_settings_key_wins_over_env(self):
+        with (
+            patch.object(browser_computer.db, "get_setting", return_value="sk-from-settings"),
+            patch.dict("os.environ", {"BOSUN_OPENAI_API_KEY": "sk-from-env"}, clear=False),
+        ):
+            self.assertEqual(
+                browser_computer.resolve_api_key(),
+                ("sk-from-settings", "settings"),
+            )
+
+    def test_falls_back_to_env_when_settings_empty(self):
+        with (
+            patch.object(browser_computer.db, "get_setting", return_value=""),
+            patch.dict(
+                "os.environ",
+                {"BOSUN_OPENAI_API_KEY": "", "OPENAI_API_KEY": "sk-plain-env"},
+                clear=False,
+            ),
+        ):
+            self.assertEqual(browser_computer.resolve_api_key(), ("sk-plain-env", "env"))
+
+    def test_missing_everywhere(self):
+        with (
+            patch.object(browser_computer.db, "get_setting", return_value=None),
+            patch.dict(
+                "os.environ",
+                {"BOSUN_OPENAI_API_KEY": "", "OPENAI_API_KEY": ""},
+                clear=False,
+            ),
+        ):
+            self.assertEqual(browser_computer.resolve_api_key(), ("", ""))
+
+    def test_mask_never_leaks_full_key(self):
+        masked = browser_computer.mask_api_key("sk-proj-1234567890abcd")
+        self.assertNotIn("1234567890", masked)
+        self.assertTrue(masked.endswith("abcd"))
+        self.assertEqual(browser_computer.mask_api_key(""), "")
+
+
+class BrowserApiKeySettingTest(unittest.TestCase):
+    def _run_update(self, stored: dict, **body_kwargs):
+        def get_setting(key, default=None):
+            return stored.get(key, default)
+
+        with (
+            patch.object(settings.db, "get_setting", side_effect=get_setting),
+            patch.object(settings.db, "set_setting", side_effect=stored.__setitem__),
+            patch.object(settings.scheduler, "tick"),
+            patch.object(settings.agent_skills, "sync_installed_engines"),
+            patch.object(settings.agent_skills.engine_updates, "installed_engines", return_value={}),
+            patch.object(settings.browser_computer, "availability", return_value={}),
+            patch.object(settings.browser_computer, "invalidate_availability") as invalidate,
+        ):
+            settings.update_settings(settings.Settings(max_concurrent=3, **body_kwargs))
+        return invalidate
+
+    def test_saves_key_and_drops_availability_cache(self):
+        stored: dict = {}
+        invalidate = self._run_update(stored, browser_api_key="  sk-typed-in-ui  ")
+        self.assertEqual(stored["browser_openai_api_key"], "sk-typed-in-ui")
+        invalidate.assert_called_once()
+
+    def test_omitting_field_keeps_existing_key(self):
+        stored = {"browser_openai_api_key": "sk-kept"}
+        self._run_update(stored)
+        self.assertEqual(stored["browser_openai_api_key"], "sk-kept")
+
+    def test_empty_string_clears_key(self):
+        stored = {"browser_openai_api_key": "sk-old"}
+        self._run_update(stored, browser_api_key="")
+        self.assertEqual(stored["browser_openai_api_key"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,7 +59,13 @@ const DEFAULT_SETTINGS: AppSettings = {
   omp_thinking_options: [{ value: "", label: "默认" }],
   kimi_model: "",
   kimi_model_options: [{ value: "", label: "默认" }],
-  browser: { available: false, missing: ["正在检测 Browser 运行条件"], model: "gpt-5.6" },
+  browser: {
+    available: false,
+    missing: ["正在检测 Browser 运行条件"],
+    model: "gpt-5.6",
+    api_key_source: "",
+    api_key_hint: "",
+  },
 };
 const PULL_REFRESH_TRIGGER_PX = 72;
 const PULL_REFRESH_MAX_PX = 96;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -42,7 +42,13 @@ export type AppSettings = {
     available: boolean;
     missing: string[];
     model: string;
+    /** "settings" = 页面填的，"env" = 环境变量，"" = 未配置 */
+    api_key_source: "settings" | "env" | "";
+    /** 掩码，明文不出后端 */
+    api_key_hint: string;
   };
+  /** 只写字段：保存 Browser Computer Use 的 OpenAI Key；不传表示不改动，"" 表示清除 */
+  browser_api_key?: string;
 };
 
 export type StorageInfo = {

--- a/frontend/src/components/SettingsView.tsx
+++ b/frontend/src/components/SettingsView.tsx
@@ -34,7 +34,8 @@ function Section({ title, hint, aside, children }: { title: string; hint?: strin
 
 function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1.5">
+    // 网格而非 flex-wrap：hint 再长也只在左列换行，右侧控件始终贴右对齐不掉行
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-4 gap-y-1.5">
       <div className="min-w-0">
         <div className="text-sm text-dh-tsoft">{label}</div>
         {hint && <div className="text-[11px] text-slate-400">{hint}</div>}
@@ -425,12 +426,14 @@ function AccessControl({ auth, onAuthChanged }: { auth: AuthStatus; onAuthChange
   );
 }
 
-/** 设置分组：小节标题 + 桌面端两列网格(默认 stretch，配合卡片 h-full 同行等高)。 */
+/** 设置分组：小节标题 + 自适应多列网格。
+ * items-start 让卡片按内容高度收缩（不再被同行最高的卡撑出大片留白），
+ * 宽屏最多三列，避免正文只挤在中间一条。 */
 function SettingsGroup({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <section className="space-y-3">
       <h3 className="px-1 text-[11px] font-semibold uppercase tracking-wider text-dh-muted">{label}</h3>
-      <div className="grid gap-4 lg:grid-cols-2">{children}</div>
+      <div className="grid items-start gap-4 md:grid-cols-2 xl:grid-cols-3">{children}</div>
     </section>
   );
 }
@@ -456,6 +459,77 @@ const ENGINE_INTRO: Record<Engine, { blurb: string; install: string }> = {
   kimi: { blurb: "Moonshot 的 Kimi Code CLI，自带 provider 凭据", install: "npm i -g @moonshot-ai/kimi-code" },
   browser: { blurb: "OpenAI Computer Use + 隔离 Chromium", install: "playwright install chromium" },
 };
+
+/** Browser Computer Use 的 OpenAI Key：存后端设置（数据库），不再依赖环境变量。
+ * 明文只在提交那一刻存在于本地 state，后端只回掩码。 */
+function BrowserApiKeyField({
+  browser,
+  onChange,
+}: {
+  browser: AppSettings["browser"];
+  onChange: (patch: Partial<AppSettings>) => Promise<void>;
+}) {
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const fromSettings = browser.api_key_source === "settings";
+
+  async function save(value: string) {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await onChange({ browser_api_key: value });
+      setDraft("");
+      toast(value ? "API Key 已保存" : "API Key 已清除", "success");
+    } catch (err) {
+      toast(`保存失败：${readDetail(err)}`, "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clear() {
+    const ok = await confirmDialog("清除后 Browser Computer Use 将回退到环境变量（若未设置则不可用）。确定清除？", { danger: true });
+    if (ok) await save("");
+  }
+
+  return (
+    <Field
+      label="API Key"
+      hint={
+        fromSettings
+          ? `已保存 ${browser.api_key_hint}`
+          : browser.api_key_source === "env"
+            ? `当前用环境变量 ${browser.api_key_hint}；在此填写可覆盖`
+            : "OpenAI API Key，保存在本机数据库，仅用于调用 computer use 与语音转写"
+      }
+    >
+      <div className="flex items-center gap-2">
+        <input
+          type="password"
+          autoComplete="off"
+          placeholder={fromSettings ? "填写以替换" : "sk-…"}
+          className="w-44 rounded-md border border-dh-bsoft bg-dh-surface px-2.5 py-1 font-mono text-xs text-dh-text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        <button
+          type="button"
+          disabled={saving || !draft.trim()}
+          onClick={() => void save(draft.trim())}
+          className="shrink-0 rounded-md border border-dh-bsoft bg-dh-surface px-3 py-1 text-sm text-dh-tsoft transition hover:border-dh-accent hover:text-dh-text disabled:cursor-not-allowed disabled:opacity-50"
+        >{saving ? "保存中…" : "保存"}</button>
+        {fromSettings && (
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => void clear()}
+            className="shrink-0 rounded-md border border-rose-500/40 px-3 py-1 text-sm text-rose-500 transition hover:bg-rose-500/20 disabled:opacity-50"
+          >清除</button>
+        )}
+      </div>
+    </Field>
+  );
+}
 
 /** 未安装引擎的灰态摘要卡。其余界面对未安装引擎一律隐藏，
  * 只在设置页保留一张占位卡，成对展示「支持什么」和「怎么装」。 */
@@ -597,7 +671,7 @@ export function SettingsView({
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl space-y-7 p-4 lg:p-6">
+    <div className="mx-auto w-full max-w-[1760px] space-y-7 p-4 lg:p-6">
       <SettingsGroup label="执行引擎">
       {!showClaude && <UninstalledEngineCard engine="claude" />}
       {showClaude && (
@@ -763,6 +837,7 @@ export function SettingsView({
             {settings.browser.model}
           </code>
         </Field>
+        <BrowserApiKeyField browser={settings.browser} onChange={onChange} />
         <Field label="运行条件">
           {settings.browser.available ? (
             <span className="text-sm text-emerald-400">API Key、Playwright 与 Chromium 已就绪</span>
@@ -777,12 +852,12 @@ export function SettingsView({
       </SettingsGroup>
 
       <SettingsGroup label="任务编排">
-        <div className="min-w-0 lg:col-span-2">
+        <div className="min-w-0 md:col-span-2 xl:col-span-3">
           <OrchestrationSettings settings={settings} />
         </div>
       </SettingsGroup>
 
-      <SettingsGroup label="运行与系统">
+      <SettingsGroup label="运行与数据">
         <Section title="运行" hint="控制任务并发与额度保护。">
           <Field label="并发上限">
             <input
@@ -845,11 +920,9 @@ export function SettingsView({
               {settings.report_skill_enabled ? "已开启" : "已关闭"}
             </label>
           </Field>
-          <div className="space-y-2 border-t border-dh-bsoft pt-3">
-            <div>
-              <div className="text-sm text-dh-tsoft">Agent Skills 安装目录</div>
-              <div className="text-[11px] text-slate-400">留空时使用各 CLI 的全局默认目录；修改后只迁移 Bosun 自有技能。</div>
-            </div>
+        </Section>
+        <Section title="Agent Skills 安装目录" hint="留空时使用各 CLI 的全局默认目录；修改后只迁移 Bosun 自有技能。">
+          <div className="space-y-2">
             {SKILL_ENGINES.map((engine) => {
               const info = settings.agent_skill_paths[engine];
               const value = settings.skill_path_overrides[engine] ?? "";
@@ -873,6 +946,12 @@ export function SettingsView({
             })}
           </div>
         </Section>
+        <StorageOverview />
+      </SettingsGroup>
+
+      <SettingsGroup label="维护与安全">
+        <BosunVersion />
+        <AccessControl auth={auth} onAuthChanged={onAuthChanged} />
         <Section title="系统" hint="管理由 Bosun.app 托管的后端服务。">
           <Field label="后端服务" hint="只重启后端；状态栏图标和菜单不受影响。">
             <button
@@ -883,12 +962,6 @@ export function SettingsView({
             >重启后端</button>
           </Field>
         </Section>
-        <StorageOverview />
-      </SettingsGroup>
-
-      <SettingsGroup label="维护与安全">
-        <BosunVersion />
-        <AccessControl auth={auth} onAuthChanged={onAuthChanged} />
       </SettingsGroup>
     </div>
   );


### PR DESCRIPTION
## 变更

**API Key 页面化**（原来只认环境变量）
- `browser_computer.resolve_api_key()`：优先级 **设置页 > `BOSUN_OPENAI_API_KEY` > `OPENAI_API_KEY`**，环境变量降级为回退，老部署不受影响
- Key 存本机 SQLite `browser_openai_api_key`；`availability()` 只回 `api_key_source` 与掩码 `api_key_hint`，**明文不出后端**
- `PUT /api/settings` 的 `browser_api_key` 为可选：不传=不动、`""`=清除，避免保存其它设置时回传密钥；写入后失效可用性缓存
- 语音转写用的是同一把 Key，一并改走统一入口
- 设置页 Browser 卡新增 API Key 输入 / 保存 / 清除（清除有二次确认）

**设置页布局**（原来固定两列且卡片强制等高，右侧大片留白）
- 容器 `max-w-5xl` → 1760px；分组网格 `md:2 / xl:3` 且 `items-start` 按内容自适应高度
- `Field` 改网格布局，长说明不再把开关挤到下一行
- 拆出「Agent Skills 安装目录」独立卡片，「系统」并入维护分组

## 验证

- 新增 `backend/tests/test_browser_api_key.py`（7 例，先 red 后 green）：优先级、回退、掩码不泄漏、不传不清空、传空清除、缓存失效 → **7 passed**
- 端到端 TestClient（临时数据目录）：PUT 后 `api_key_source=settings` / `api_key_hint=sk-…abcd` / `missing` 变空；GET 全文确认明文未泄漏；普通保存不清空；传 `""` 清除成功
- 回归：`backend/tests/` 49 passed；`tsc --noEmit` 无错误；前端 build 通过

## 注意

合并后需重启后端才生效。