### PR TITLE
feat: 增加内置角色与开发编排

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test --experimental-strip-types tests/*.test.ts",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/frontend/src/components/OrchestrationSettings.tsx
+++ b/frontend/src/components/OrchestrationSettings.tsx
@@ -5,6 +5,15 @@ import { useCallback, useEffect, useState } from "react";
 import { api, type AppSettings } from "../api";
 import { engineBadgeClass, engineName, engineShort } from "../engines";
 import { useAvailableEngines } from "../installedEngines";
+import {
+  BUILT_IN_ORCHESTRATIONS,
+  BUILT_IN_ROLES,
+  applyRolePreset,
+  getBuiltInRole,
+  nextAvailableOrchestrationName,
+  type BuiltInOrchestration,
+  type BuiltInRoleId,
+} from "../orchestrationPresets";
 import { confirmDialog, toast } from "../overlay";
 import type { Engine, OrchestrationTemplate } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
@@ -53,6 +62,23 @@ function emptyDraft(engines: CodingEngine[]): Draft {
       emptyStep(first, "方案负责人", "分析原始任务并输出清晰、可执行的方案。"),
       emptyStep(second, "实施负责人", "结合原始任务和前序产物完成实现与验证。"),
     ],
+  };
+}
+
+function draftFromPreset(preset: BuiltInOrchestration, engines: CodingEngine[], existingNames: readonly string[]): Draft {
+  const fallbackEngine = engines[0] ?? "claude";
+  return {
+    id: null,
+    name: nextAvailableOrchestrationName(preset.name, existingNames),
+    enabled: true,
+    steps: preset.steps.map(({ roleId, preferredEngine }) => {
+      const role = getBuiltInRole(roleId);
+      return emptyStep(
+        engines.includes(preferredEngine) ? preferredEngine : fallbackEngine,
+        role.name,
+        role.rolePrompt,
+      );
+    }),
   };
 }
 
@@ -165,6 +191,7 @@ export function OrchestrationSettings({ settings }: { settings: AppSettings }) {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const { busy, run } = useSingleFlight();
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+  const developmentPreset = BUILT_IN_ORCHESTRATIONS[0];
 
   const load = useCallback(async () => {
     setTemplates(await api.orchestrations.list());
@@ -183,6 +210,13 @@ export function OrchestrationSettings({ settings }: { settings: AppSettings }) {
     setDraft((current) => current ? {
       ...current,
       steps: current.steps.map((step, stepIndex) => stepIndex === index ? { ...step, ...patch } : step),
+    } : current);
+  }
+
+  function fillFromRolePreset(index: number, roleId: BuiltInRoleId) {
+    setDraft((current) => current ? {
+      ...current,
+      steps: current.steps.map((step, stepIndex) => stepIndex === index ? applyRolePreset(step, roleId) : step),
     } : current);
   }
 
@@ -263,11 +297,20 @@ export function OrchestrationSettings({ settings }: { settings: AppSettings }) {
           <h2 className="text-sm font-semibold text-dh-text">任务编排</h2>
           <p className="mt-1 text-xs text-slate-400">按顺序运行多个自定义角色；角色提示词会与原任务、前序产物一起注入 CLI。</p>
         </div>
-        <button
-          type="button"
-          onClick={() => openDraft(emptyDraft(engines))}
-          className="rounded-lg bg-dh-accent px-3 py-1.5 text-sm font-medium text-dh-accfg hover:bg-dh-acchov"
-        >+ 新建编排</button>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            disabled={engines.length === 0}
+            onClick={() => openDraft(draftFromPreset(developmentPreset, engines, templates.map((template) => template.name)))}
+            title={developmentPreset.description}
+            className="rounded-lg border border-dh-accent/50 px-3 py-1.5 text-sm font-medium text-dh-accent hover:bg-dh-accent/10 disabled:opacity-40"
+          >使用内置“{developmentPreset.name}”</button>
+          <button
+            type="button"
+            onClick={() => openDraft(emptyDraft(engines))}
+            className="rounded-lg bg-dh-accent px-3 py-1.5 text-sm font-medium text-dh-accfg hover:bg-dh-acchov"
+          >+ 新建编排</button>
+        </div>
       </div>
 
       {templates.length === 0 && !draft ? (
@@ -331,6 +374,25 @@ export function OrchestrationSettings({ settings }: { settings: AppSettings }) {
 
           {selected && models && (
             <div className="rounded-lg border border-dh-bsoft bg-dh-surface p-3">
+              <div className="mb-3 flex flex-wrap items-end gap-2 rounded-lg border border-dh-bsoft bg-dh-soft p-2.5">
+                <label className="min-w-56">
+                  <span className="mb-1 block text-xs text-dh-muted">从内置角色填充</span>
+                  <select
+                    value=""
+                    onChange={(event) => {
+                      const roleId = event.target.value as BuiltInRoleId;
+                      if (roleId) fillFromRolePreset(selectedIndex, roleId);
+                    }}
+                    className="w-full rounded-md border border-dh-bsoft bg-dh-surface px-2.5 py-1.5 text-sm"
+                  >
+                    <option value="">选择角色预设…</option>
+                    {BUILT_IN_ROLES.map((role) => (
+                      <option key={role.id} value={role.id}>{role.name} · {role.description}</option>
+                    ))}
+                  </select>
+                </label>
+                <p className="pb-1 text-xs text-dh-muted">仅填充角色名称和提示词，不改变 CLI、模型与推理强度；填充后可继续编辑。</p>
+              </div>
               <div className="flex flex-wrap items-end gap-2">
                 <label className="min-w-40 flex-1">
                   <span className="mb-1 block text-xs text-dh-muted">第 {selectedIndex + 1} 步角色名称</span>

--- a/frontend/src/orchestrationPresets.ts
+++ b/frontend/src/orchestrationPresets.ts
@@ -1,0 +1,167 @@
+import type { Engine } from "./types";
+
+type CodingEngine = Exclude<Engine, "browser">;
+
+export type BuiltInRole = {
+  id: string;
+  name: string;
+  description: string;
+  rolePrompt: string;
+};
+
+export const BUILT_IN_ROLES = [
+  {
+    id: "requirements-analysis",
+    name: "需求分析",
+    description: "明确目标、边界与验收标准",
+    rolePrompt: `你是需求分析负责人。结合原始任务与前序产物，识别用户真正要解决的问题，并把模糊要求转成可验证的交付目标。
+
+工作要求：
+- 梳理目标、用户场景、范围、非目标和关键约束。
+- 找出会改变实现方向的歧义与缺失信息；能够从现有上下文确认的，不重复追问。
+- 给出明确的验收标准、边界情况、依赖和主要风险。
+- 不提前实现，不擅自扩大需求。
+
+输出要求：先给结论，再列需求清单、验收标准、风险与待确认项；若没有待确认项，明确写“可继续”。`,
+  },
+  {
+    id: "solution-design",
+    name: "方案设计",
+    description: "基于现状给出最小可行方案",
+    rolePrompt: `你是方案设计负责人。分析原始任务、前序产物与项目现状，输出范围清晰、可以直接执行和验收的技术方案。
+
+工作要求：
+- 先定位相关模块、现有约定和可复用实现，再做设计。
+- 说明关键数据流、接口或状态变化，以及每项取舍的理由。
+- 优先选择能解决根因的最小方案，明确不做什么。
+- 把实施拆成可独立验证的步骤，并指出风险与回滚方式。
+
+输出要求：包含现状判断、推荐方案、影响范围、实施步骤、验证方法和残余风险；不得直接修改代码。`,
+  },
+  {
+    id: "plan-review",
+    name: "方案审计",
+    description: "在实施前审查方案漏洞",
+    rolePrompt: `你是独立方案审计人。审查原始任务与前序方案，验证它是否真正覆盖需求，并在实施前找出错误假设、遗漏和不必要的复杂度。
+
+工作要求：
+- 逐项核对需求、验收标准与方案步骤是否对应。
+- 检查根因判断、边界条件、兼容性、数据安全和回滚路径。
+- 区分阻塞问题、建议项和信息项，不把个人偏好包装成缺陷。
+- 对每个问题给出具体证据与最小修订建议。
+
+输出要求：先给“通过 / 修订后通过 / 不通过”结论，再按严重度列发现；最后给可供实施者直接采用的修订版要点。`,
+  },
+  {
+    id: "implementation",
+    name: "实施开发",
+    description: "按已审方案完成实现与自测",
+    rolePrompt: `你是实施负责人。依据原始任务和已经审定的前序产物完成代码修改，并提供可复核的验证证据。
+
+工作要求：
+- 修改前读取项目约定和相关实现，保持现有架构、命名与界面风格。
+- 只改交付目标需要的内容；解决根因，不顺手重构无关代码。
+- 对可测试逻辑先写失败测试，再做最小实现使其通过。
+- 完成后检查变更差异，运行目标测试及受影响回归。
+
+输出要求：说明改了什么、涉及哪些文件、运行了哪些验证及结果；未验证或仍有风险的部分必须明确披露。`,
+  },
+  {
+    id: "code-review",
+    name: "代码审查",
+    description: "检查正确性、回归与维护性",
+    rolePrompt: `你是独立代码审查人。结合原始任务、前序产物与实际变更，判断实现是否满足验收标准并且没有引入不可接受的风险。
+
+工作要求：
+- 先核对需求覆盖，再检查正确性、边界条件、错误处理、并发与安全问题。
+- 阅读实际差异和相关调用链，不依据摘要臆测。
+- 只报告可复现、可定位的问题，并标明严重度与影响。
+- 识别测试缺口和潜在回归，但不把风格偏好当作缺陷。
+
+输出要求：按阻塞、建议、信息三个等级列出发现，包含文件位置、证据和修复建议；没有问题时明确说明审查范围与残余风险。`,
+  },
+  {
+    id: "test-validation",
+    name: "测试验证",
+    description: "按验收标准独立验证结果",
+    rolePrompt: `你是测试与验收负责人。根据原始任务、验收标准和前序实现，对最终结果进行独立验证，而不是复述实施者的结论。
+
+工作要求：
+- 覆盖主流程、关键边界、失败路径和最可能的回归点。
+- 运行能够直接证明结论的测试、构建或交互检查，并阅读完整结果。
+- 对界面变更检查实际渲染、控制台错误和核心交互。
+- 发现失败时给出稳定复现步骤与观察证据，不擅自掩盖。
+
+输出要求：先给“通过 / 有条件通过 / 不通过”结论，再列验证环境、操作或命令、实际结果、失败证据和未覆盖风险。`,
+  },
+  {
+    id: "security-audit",
+    name: "安全审计",
+    description: "检查输入、权限、密钥与数据风险",
+    rolePrompt: `你是安全审计负责人。围绕本次任务实际涉及的攻击面，检查实现是否正确处理外部输入、身份权限、敏感数据和依赖边界。
+
+工作要求：
+- 从入口追踪数据流，检查校验、鉴权、授权和输出编码。
+- 检查密钥、令牌和个人数据是否可能被硬编码、持久化或写入日志。
+- 评估注入、越权、数据破坏、信息泄露及不安全默认值。
+- 发现必须基于实际代码与可行攻击路径，避免泛化清单。
+
+输出要求：按风险等级列出受影响位置、利用前提、影响和修复建议；若未发现问题，说明审计边界和未覆盖攻击面。`,
+  },
+  {
+    id: "documentation",
+    name: "文档整理",
+    description: "沉淀用法、变更与关键决策",
+    rolePrompt: `你是技术文档负责人。根据原始任务和已完成的前序产物，更新用户真正需要的说明，并确保文档与最终实现一致。
+
+工作要求：
+- 识别受影响的使用说明、配置、接口、示例和变更记录。
+- 沿用项目既有术语与文档结构，不复制代码已经清楚表达的细节。
+- 示例必须可运行且不包含真实密钥、弱密码或环境专属数据。
+- 记录重要限制、兼容性影响和必要的迁移或回滚步骤。
+
+输出要求：列出更新位置和核心内容；若无需改文档，说明判断依据，不为凑交付而创建无价值文档。`,
+  },
+] as const satisfies readonly BuiltInRole[];
+
+export type BuiltInRoleId = (typeof BUILT_IN_ROLES)[number]["id"];
+
+export type BuiltInOrchestration = {
+  id: string;
+  name: string;
+  description: string;
+  steps: readonly { roleId: BuiltInRoleId; preferredEngine: CodingEngine }[];
+};
+
+export const BUILT_IN_ORCHESTRATIONS = [
+  {
+    id: "development",
+    name: "开发",
+    description: "方案设计 → 方案审计 → 实施开发 → 测试验证",
+    steps: [
+      { roleId: "solution-design", preferredEngine: "codex" },
+      { roleId: "plan-review", preferredEngine: "claude" },
+      { roleId: "implementation", preferredEngine: "claude" },
+      { roleId: "test-validation", preferredEngine: "codex" },
+    ],
+  },
+] as const satisfies readonly BuiltInOrchestration[];
+
+export function getBuiltInRole(roleId: BuiltInRoleId): (typeof BUILT_IN_ROLES)[number] {
+  const role = BUILT_IN_ROLES.find((item) => item.id === roleId);
+  if (!role) throw new Error(`未知内置角色：${roleId}`);
+  return role;
+}
+
+export function applyRolePreset<T extends { name: string; role_prompt: string }>(step: T, roleId: BuiltInRoleId): T {
+  const role = getBuiltInRole(roleId);
+  return { ...step, name: role.name, role_prompt: role.rolePrompt };
+}
+
+export function nextAvailableOrchestrationName(baseName: string, existingNames: readonly string[]): string {
+  const names = new Set(existingNames.map((name) => name.trim()));
+  if (!names.has(baseName)) return baseName;
+  let suffix = 2;
+  while (names.has(`${baseName} ${suffix}`)) suffix += 1;
+  return `${baseName} ${suffix}`;
+}

--- a/frontend/tests/orchestrationPresets.test.ts
+++ b/frontend/tests/orchestrationPresets.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  BUILT_IN_ORCHESTRATIONS,
+  BUILT_IN_ROLES,
+  applyRolePreset,
+  nextAvailableOrchestrationName,
+} from "../src/orchestrationPresets.ts";
+
+test("built-in roles have unique names and actionable prompts", () => {
+  assert.equal(new Set(BUILT_IN_ROLES.map((role) => role.id)).size, BUILT_IN_ROLES.length);
+  assert.equal(new Set(BUILT_IN_ROLES.map((role) => role.name)).size, BUILT_IN_ROLES.length);
+  for (const role of BUILT_IN_ROLES) {
+    assert.ok(role.rolePrompt.length >= 80, `${role.name} prompt should be detailed`);
+    assert.match(role.rolePrompt, /输出要求/);
+  }
+});
+
+test("development orchestration contains four resolvable roles", () => {
+  const development = BUILT_IN_ORCHESTRATIONS.find((item) => item.id === "development");
+  assert.ok(development);
+  assert.equal(development.steps.length, 4);
+  for (const step of development.steps) {
+    assert.ok(BUILT_IN_ROLES.some((role) => role.id === step.roleId));
+  }
+});
+
+test("applying a role preset preserves runtime configuration", () => {
+  const step = {
+    key: "step-1",
+    name: "旧名称",
+    role_prompt: "旧提示词",
+    engine: "codex",
+    model: "gpt-5.6-sol",
+    reasoning_effort: "high",
+  } as const;
+
+  const updated = applyRolePreset(step, "code-review");
+
+  assert.equal(updated.name, "代码审查");
+  assert.notEqual(updated.role_prompt, step.role_prompt);
+  assert.equal(updated.engine, step.engine);
+  assert.equal(updated.model, step.model);
+  assert.equal(updated.reasoning_effort, step.reasoning_effort);
+  assert.equal(updated.key, step.key);
+});
+
+test("built-in orchestration gets a saveable name when copies already exist", () => {
+  assert.equal(nextAvailableOrchestrationName("开发", []), "开发");
+  assert.equal(nextAvailableOrchestrationName("开发", ["开发"]), "开发 2");
+  assert.equal(nextAvailableOrchestrationName("开发", ["开发", "开发 2"]), "开发 3");
+});


### PR DESCRIPTION
## 变更摘要
- 新增 8 个可编辑的内置角色与完整提示词
- 新增“开发”内置编排入口，默认生成方案设计、方案审计、实施开发、测试验证四步链路
- 角色预设只替换名称与提示词，并为重复编排名生成可保存名称
- 新增预设行为测试与前端测试脚本

## 验证
- `npm test`：4/4 通过
- `npm run build`：通过（仅保留项目既有的大 chunk 提示）
- Playwright：内置入口、四步链路、重名处理、角色填充与运行配置保持均通过
- `git diff --cached --check`：通过