### PR TITLE
fix: 多端同看一个任务时手机端不再把电脑端终端压窄

### DIFF
--- a/backend/app/routers/ws.py
+++ b/backend/app/routers/ws.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from .. import auth, events, scheduler
 from ..config import LOG_DIR
 from ..pty_session import read_terminal_backlog
+from ..terminal_viewport import ViewportRegistry
 
 router = APIRouter()
 
@@ -25,6 +26,28 @@ WS_UNAUTHORIZED = 4401
 BACKLOG_TRUNCATED_META = "\x00meta:backlog_truncated"
 # 跨源页面直连被拒（同源部署下浏览器里只有恶意网页会跨源连 WS）
 WS_FORBIDDEN_ORIGIN = 4403
+# 尺寸仲裁结果广播帧：多端同看时 PTY 只有一份 winsize，客户端据此按同一网格渲染
+# （小屏端整体缩放查看），而不是各自 fit 后互相把对方的画面压窄。
+SIZE_META_PREFIX = "\x00meta:size:"
+
+# 每个连接上报自己期望的尺寸，PTY 取所有活跃连接的最大值，详见 terminal_viewport
+_viewports = ViewportRegistry()
+# task_id → 该任务所有连接的出站队列，用于广播仲裁结果。用队列本身做连接标识：
+# 每个连接 subscribe 到一个独立队列，天然唯一。
+_task_clients: dict[int, set[asyncio.Queue]] = {}
+
+
+def _broadcast_size(task_id: int, size: tuple[int, int]) -> None:
+    """把仲裁后的尺寸推给该任务的所有连接。
+
+    走各连接自己的出站队列而不是直接 send：每个连接只有 pump_out 一个发送方，
+    避免与正在发送的终端字节流并发写同一个 WebSocket 而交错帧。
+    """
+    rows, cols = size
+    frame = f"{SIZE_META_PREFIX}{rows},{cols}"
+    for q in tuple(_task_clients.get(task_id, ())):
+        with suppress(Exception):
+            q.put_nowait(frame)
 
 
 def _same_origin(ws: WebSocket) -> bool:
@@ -120,14 +143,35 @@ async def session_ws(ws: WebSocket, task_id: int):
     if backlog.data:
         await ws.send_bytes(backlog.data)
     q = session.subscribe()
+    _task_clients.setdefault(task_id, set()).add(q)
+    # 本连接是否已上报过尺寸：第一帧无论仲裁结果是否变化都要强制整屏补画，
+    # 否则新连上的客户端在别人已经占着最大尺寸时收不到 TUI 的完整画面。
+    viewport_attached = False
 
     async def pump_out():
         try:
             while True:
                 data = await q.get()
-                await ws.send_bytes(data)
+                if isinstance(data, str):
+                    await ws.send_text(data)
+                else:
+                    await ws.send_bytes(data)
         except Exception:
             pass
+
+    def apply_viewport(rows: int, cols: int, *, force_redraw: bool) -> None:
+        """记录本连接的期望尺寸并按仲裁结果调整 PTY。尺寸非法时抛 ValueError。"""
+        nonlocal viewport_attached
+        previous = _viewports.effective(task_id)
+        effective = _viewports.set(task_id, q, rows, cols)
+        first_frame = not viewport_attached
+        viewport_attached = True
+        if force_redraw or first_frame:
+            session.redraw(*effective)
+        elif effective != previous:
+            session.resize(*effective)
+        if first_frame or effective != previous:
+            _broadcast_size(task_id, effective)
 
     out_task = asyncio.create_task(pump_out())
     try:
@@ -137,18 +181,13 @@ async def session_ws(ws: WebSocket, task_id: int):
                 break
             if "text" in msg and msg["text"] is not None:
                 text = msg["text"]
-                if text.startswith("\x00redraw:"):
+                if text.startswith("\x00redraw:") or text.startswith("\x00resize:"):
                     try:
                         _, rc = text.split(":", 1)
                         rows, cols = rc.split(",")
-                        session.redraw(int(rows), int(cols))
-                    except ValueError:
-                        pass
-                elif text.startswith("\x00resize:"):
-                    try:
-                        _, rc = text.split(":", 1)
-                        rows, cols = rc.split(",")
-                        session.resize(int(rows), int(cols))
+                        apply_viewport(
+                            int(rows), int(cols), force_redraw=text.startswith("\x00redraw:")
+                        )
                     except ValueError:
                         pass
                 else:
@@ -165,6 +204,17 @@ async def session_ws(ws: WebSocket, task_id: int):
         with suppress(asyncio.CancelledError):
             await out_task
         session.unsubscribe(q)
+        clients = _task_clients.get(task_id)
+        if clients is not None:
+            clients.discard(q)
+            if not clients:
+                _task_clients.pop(task_id, None)
+        # 本连接退出后重新仲裁：最宽的客户端走了，PTY 该缩回剩下那些人的尺寸
+        previous = _viewports.effective(task_id)
+        remaining = _viewports.drop(task_id, q)
+        if remaining is not None and remaining != previous:
+            session.resize(*remaining)
+            _broadcast_size(task_id, remaining)
 
 
 @router.websocket("/ws/events")

--- a/backend/app/terminal_viewport.py
+++ b/backend/app/terminal_viewport.py
@@ -1,0 +1,55 @@
+"""多端同看一个任务时的 PTY 窗口尺寸仲裁。
+
+一个任务只有一个子进程、一个 PTY，PTY 只有一份 winsize；多个 WebSocket 只是订阅
+同一份已经排好版的字节流，做不到「每个连接各自一个尺寸」。谁都能直接改 winsize 的
+结果是：手机端一连上来就把 PTY 压到手机宽度，电脑端看到的全屏 TUI 跟着被重排。
+
+这里按连接记录各自期望的尺寸，PTY 取所有活跃连接的最大值：大屏端永远按自己的宽度
+渲染、不被小屏端压窄；小屏端拿仲裁结果回来按同一网格渲染并整体缩放查看。小屏端单独
+连接时最大值就是它自己，体验不受影响。
+"""
+from __future__ import annotations
+
+# xterm 与 PTY 的合理上限，超出即视为畸形控制帧（而非某个超宽显示器）
+MAX_TERMINAL_DIMENSION = 1000
+
+ConnKey = object
+Size = tuple[int, int]
+
+
+def _validate(rows: int, cols: int) -> Size:
+    if not (1 <= rows <= MAX_TERMINAL_DIMENSION and 1 <= cols <= MAX_TERMINAL_DIMENSION):
+        raise ValueError(f"invalid terminal size: {rows}x{cols}")
+    return rows, cols
+
+
+class ViewportRegistry:
+    """task_id → {连接 → 该连接期望的 (rows, cols)}，仲裁结果取各维度最大值。"""
+
+    def __init__(self) -> None:
+        self._by_task: dict[int, dict[ConnKey, Size]] = {}
+
+    def set(self, task_id: int, conn: ConnKey, rows: int, cols: int) -> Size:
+        """记录一个连接的期望尺寸，返回仲裁后的 (rows, cols)。尺寸非法时抛 ValueError。"""
+        size = _validate(rows, cols)  # 先校验，非法值不得污染已有状态
+        self._by_task.setdefault(task_id, {})[conn] = size
+        effective = self.effective(task_id)
+        assert effective is not None  # 刚写入过，必然非空
+        return effective
+
+    def drop(self, task_id: int, conn: ConnKey) -> Size | None:
+        """连接断开；返回剩余连接的仲裁结果，已无连接则返回 None。"""
+        sizes = self._by_task.get(task_id)
+        if sizes is None:
+            return None
+        sizes.pop(conn, None)
+        if not sizes:
+            self._by_task.pop(task_id, None)
+            return None
+        return self.effective(task_id)
+
+    def effective(self, task_id: int) -> Size | None:
+        sizes = self._by_task.get(task_id)
+        if not sizes:
+            return None
+        return max(rows for rows, _ in sizes.values()), max(cols for _, cols in sizes.values())

--- a/backend/tests/test_terminal_viewport.py
+++ b/backend/tests/test_terminal_viewport.py
@@ -1,0 +1,66 @@
+import unittest
+
+from backend.app.terminal_viewport import MAX_TERMINAL_DIMENSION, ViewportRegistry
+
+
+class ViewportRegistryTest(unittest.TestCase):
+    def setUp(self):
+        self.reg = ViewportRegistry()
+
+    def test_single_connection_gets_its_own_size(self):
+        self.assertEqual(self.reg.set(1, "a", 40, 120), (40, 120))
+
+    def test_narrow_client_does_not_shrink_the_wide_one(self):
+        self.reg.set(1, "desktop", 40, 200)
+        # 手机端连上来并上报自己的窄尺寸，PTY 仍按最大值走
+        self.assertEqual(self.reg.set(1, "phone", 20, 45), (40, 200))
+
+    def test_dimensions_are_maximised_independently(self):
+        self.reg.set(1, "wide", 20, 200)
+        self.assertEqual(self.reg.set(1, "tall", 60, 80), (60, 200))
+
+    def test_dropping_the_wide_client_shrinks_back(self):
+        self.reg.set(1, "desktop", 40, 200)
+        self.reg.set(1, "phone", 20, 45)
+        self.assertEqual(self.reg.drop(1, "desktop"), (20, 45))
+
+    def test_dropping_the_last_client_returns_none(self):
+        self.reg.set(1, "only", 40, 120)
+        self.assertIsNone(self.reg.drop(1, "only"))
+        self.assertIsNone(self.reg.effective(1))
+
+    def test_dropping_an_unknown_connection_is_a_noop(self):
+        self.reg.set(1, "a", 40, 120)
+        self.assertEqual(self.reg.drop(1, "ghost"), (40, 120))
+
+    def test_tasks_are_isolated(self):
+        self.reg.set(1, "a", 40, 200)
+        self.assertEqual(self.reg.set(2, "b", 20, 45), (20, 45))
+
+    def test_resizing_the_same_connection_replaces_its_entry(self):
+        self.reg.set(1, "a", 40, 200)
+        self.assertEqual(self.reg.set(1, "a", 30, 100), (30, 100))
+
+    def test_effective_reads_without_mutating(self):
+        self.reg.set(1, "a", 40, 200)
+        self.assertEqual(self.reg.effective(1), (40, 200))
+        self.assertEqual(self.reg.effective(1), (40, 200))
+
+    def test_rejects_non_positive_dimensions(self):
+        for rows, cols in ((0, 80), (24, 0), (-1, 80), (24, -1)):
+            with self.assertRaises(ValueError):
+                self.reg.set(1, "a", rows, cols)
+
+    def test_rejects_absurd_dimensions(self):
+        with self.assertRaises(ValueError):
+            self.reg.set(1, "a", 24, MAX_TERMINAL_DIMENSION + 1)
+
+    def test_rejected_size_leaves_previous_state_intact(self):
+        self.reg.set(1, "a", 40, 200)
+        with self.assertRaises(ValueError):
+            self.reg.set(1, "a", 0, 0)
+        self.assertEqual(self.reg.effective(1), (40, 200))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_ws_viewport.py
+++ b/backend/tests/test_ws_viewport.py
@@ -1,0 +1,133 @@
+"""多端同看一个任务时的 PTY 尺寸仲裁（WebSocket 层）。
+
+回归的是这个现象：手机和电脑同时打开同一个任务的终端，手机端一连上/一输入，
+电脑端的终端就被重排成手机宽度。
+"""
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app import auth
+from backend.app.routers import ws as ws_router
+
+
+class FakeBacklog:
+    truncated = False
+    data = b""
+
+
+class FakeSession:
+    """只实现 ws 层用到的接口；记录 PTY 收到的尺寸调用。"""
+
+    def __init__(self):
+        self.sizes: list[tuple[int, int]] = []
+        self.queues: list = []
+
+    def read_backlog(self):
+        return FakeBacklog()
+
+    def subscribe(self):
+        import asyncio
+
+        q = asyncio.Queue()
+        self.queues.append(q)
+        return q
+
+    def unsubscribe(self, q):
+        if q in self.queues:
+            self.queues.remove(q)
+
+    def resize(self, rows, cols):
+        self.sizes.append((rows, cols))
+
+    def redraw(self, rows, cols):
+        # 真实实现是「改一次尺寸再恢复」强制 TUI 补画，最终停在 (rows, cols)
+        self.sizes.append((rows, cols))
+
+    def write(self, data):
+        pass
+
+
+def _size_metas(messages):
+    prefix = ws_router.SIZE_META_PREFIX
+    return [m[len(prefix):] for m in messages if isinstance(m, str) and m.startswith(prefix)]
+
+
+class WsViewportTest(unittest.TestCase):
+    def setUp(self):
+        app = FastAPI()
+        app.include_router(ws_router.router)
+        self.session = FakeSession()
+        self.enter = patch.object(auth, "is_enabled", return_value=False)
+        self.enter.start()
+        self.addCleanup(self.enter.stop)
+        get_session = patch.object(ws_router.scheduler, "get_session", return_value=self.session)
+        get_session.start()
+        self.addCleanup(get_session.stop)
+        self.client = TestClient(app)
+        # 注册表是模块级的，逐个用例之间必须清干净
+        ws_router._viewports = ws_router.ViewportRegistry()
+        ws_router._task_clients = {}
+
+    def _drain_text(self, socket, count):
+        return [socket.receive_text() for _ in range(count)]
+
+    def test_narrow_client_does_not_shrink_the_wide_one(self):
+        with self.client.websocket_connect("/ws/session/1") as desktop:
+            desktop.send_text("\x00resize:40,200")
+            self.assertEqual(_size_metas(self._drain_text(desktop, 1)), ["40,200"])
+            self.assertEqual(self.session.sizes[-1], (40, 200))
+
+            with self.client.websocket_connect("/ws/session/1") as phone:
+                phone.send_text("\x00resize:20,45")
+                # 手机端拿回的是仲裁结果（电脑端的尺寸），不是它自己上报的 20,45
+                self.assertEqual(_size_metas(self._drain_text(phone, 1)), ["40,200"])
+                # PTY 没有被压窄
+                self.assertEqual(self.session.sizes[-1], (40, 200))
+
+                # 手机端继续输入也不会改变 PTY 尺寸
+                phone.send_text("hello")
+                phone.send_text("\x00resize:20,45")
+                self.assertEqual(self.session.sizes[-1], (40, 200))
+
+    def test_wide_client_leaving_shrinks_back_to_the_remaining_one(self):
+        with self.client.websocket_connect("/ws/session/1") as phone:
+            phone.send_text("\x00resize:20,45")
+            self._drain_text(phone, 1)
+            with self.client.websocket_connect("/ws/session/1") as desktop:
+                desktop.send_text("\x00resize:40,200")
+                self._drain_text(desktop, 1)
+                # 电脑端接管后，手机端收到广播的新网格
+                self.assertEqual(_size_metas(self._drain_text(phone, 1)), ["40,200"])
+                self.assertEqual(self.session.sizes[-1], (40, 200))
+            # 电脑端断开 → PTY 缩回手机端自己的尺寸，并广播给手机端
+            self.assertEqual(_size_metas(self._drain_text(phone, 1)), ["20,45"])
+            self.assertEqual(self.session.sizes[-1], (20, 45))
+
+    def test_single_client_still_gets_its_own_size(self):
+        with self.client.websocket_connect("/ws/session/1") as phone:
+            phone.send_text("\x00resize:20,45")
+            self.assertEqual(_size_metas(self._drain_text(phone, 1)), ["20,45"])
+            self.assertEqual(self.session.sizes[-1], (20, 45))
+
+    def test_malformed_size_frame_is_ignored_not_typed_into_the_pty(self):
+        with patch.object(self.session, "write") as write:
+            with self.client.websocket_connect("/ws/session/1") as sock:
+                sock.send_text("\x00resize:abc,200")
+                sock.send_text("\x00resize:40,200")
+                self.assertEqual(_size_metas(self._drain_text(sock, 1)), ["40,200"])
+        write.assert_not_called()
+        self.assertEqual(self.session.sizes, [(40, 200)])
+
+    def test_registry_is_emptied_after_everyone_leaves(self):
+        with self.client.websocket_connect("/ws/session/1") as sock:
+            sock.send_text("\x00resize:40,200")
+            self._drain_text(sock, 1)
+        self.assertIsNone(ws_router._viewports.effective(1))
+        self.assertNotIn(1, ws_router._task_clients)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -22,6 +22,8 @@ import { confirmDialog, promptDialog, toast } from "../overlay";
 import { guardQuota } from "../quota";
 import { TERMINAL_SUBMIT_KEY } from "../terminalInput";
 import { installHardWrappedWebLinkProvider } from "../terminalLinks";
+import type { TerminalBox, TerminalCellSize, TerminalGrid } from "../terminalViewport";
+import { fitFontSize, naturalGrid, parseSizeMeta } from "../terminalViewport";
 import { STATUS_STYLE, taskStatusStyleKey } from "../theme";
 import type { Engine, Task } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
@@ -99,6 +101,9 @@ const PANEL_SAFE_AREA_STYLE = {
 } satisfies CSSProperties;
 const AUDIO_RECORDING_TIMEOUT_MS = 60000;
 const MAX_DEFERRED_TERMINAL_BYTES = 4 * 1024 * 1024;
+// 终端基准字号。多端同看时后端会仲裁出一个统一网格（见 terminalViewport），本端容器装不下
+// 时按比例缩小字号把整幅画面塞进来——绝不能改 cols/rows，那会和 PTY 的排版错位。
+const BASE_FONT_SIZE = 12;
 // 触摸滚动过历史后「回到最新」时，向 TUI 补发的滚轮步数与每帧步数。Claude 一侧把滚轮当
 // 菜单/列表选择处理，同步灌一大批会误触命令，所以总量克制、按帧摊开。
 const APPLICATION_SCROLL_STEPS = 48;
@@ -427,7 +432,7 @@ function TerminalView({
     stickRef.current = true;
     setAtBottom(true);
     const term = new Terminal({
-      fontSize: 12,
+      fontSize: BASE_FONT_SIZE,
       fontFamily: "ui-monospace, Menlo, monospace",
       theme: TERMINAL_THEME,
       cursorBlink: true,
@@ -466,7 +471,69 @@ function TerminalView({
     termRef.current = term;
     const disposeAltBufferWorkaround = installAltBufferScrollbackWorkaround(term);
     const disposeImeFix = isTouchDevice() ? installMobileImeInsertTextFix(term) : () => {};
+
+    // 后端仲裁出的统一网格；未收到广播（旧后端/刚连上）时按本端自然尺寸走。
+    let effectiveGrid: TerminalGrid | null = null;
+    // 基准字号下的字元像素尺寸。上报「期望尺寸」必须始终按它换算，不能用缩放后的字号，
+    // 否则「字变小 → 塞得下更多列 → 上报更大 → 仲裁更大 → 字更小」会自激。
+    let baseCell: TerminalCellSize | null = null;
+
+    type TerminalInternals = {
+      _core?: {
+        _renderService?: { dimensions?: { css?: { cell?: { width: number; height: number } } } };
+        viewport?: { scrollBarWidth?: number };
+      };
+    };
+    const internals = () => term as unknown as TerminalInternals;
+
+    const captureBaseCell = () => {
+      if (baseCell || term.options.fontSize !== BASE_FONT_SIZE) return;
+      const cell = internals()._core?._renderService?.dimensions?.css?.cell;
+      if (cell && cell.width > 0 && cell.height > 0) {
+        baseCell = { width: cell.width, height: cell.height };
+      }
+    };
+
+    // 宿主 div 与 xterm 根元素都没有内边距，可用 clientWidth/Height 直接量；
+    // 滚动条与 FitAddon 一样要扣掉，否则最右一列会被压在滚动条下面。
+    const availableBox = (): TerminalBox => {
+      const scrollBar =
+        term.options.scrollback === 0 ? 0 : (internals()._core?.viewport?.scrollBarWidth ?? 0);
+      return {
+        width: Math.max(0, terminalHost.clientWidth - scrollBar),
+        height: terminalHost.clientHeight,
+      };
+    };
+
+    const reportViewport = (rows: number, cols: number) => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(`\x00resize:${rows},${cols}`);
+      }
+    };
+
+    /** 重排终端：按仲裁网格渲染（装不下就缩字号），并把本端的自然尺寸上报给后端仲裁。 */
+    const applyLayout = (report: boolean) => {
+      captureBaseCell();
+      const box = availableBox();
+      const natural = baseCell ? naturalGrid(box, baseCell) : null;
+      if (!natural || !baseCell) {
+        // 还没量到基准字元尺寸（首帧/渲染器未就绪），退回 FitAddon 的原有行为
+        fit.fit();
+        if (report) reportViewport(term.rows, term.cols);
+        return;
+      }
+      const target = effectiveGrid ?? natural;
+      const fontSize = fitFontSize(BASE_FONT_SIZE, box, baseCell, target);
+      // 先改字号再改网格：xterm 换字号会重算字元尺寸，顺序反了这一帧会按旧字元排版
+      if (term.options.fontSize !== fontSize) term.options.fontSize = fontSize;
+      if (term.cols !== target.cols || term.rows !== target.rows) {
+        term.resize(target.cols, target.rows);
+      }
+      if (report) reportViewport(natural.rows, natural.cols);
+    };
+
     fit.fit();
+    captureBaseCell();
     // 桌面端挂载即聚焦可直接打字；移动端不自动聚焦（打开面板不弹输入法），
     // 键盘由按键栏的「键盘」键唤起，键入直接进 PTY——@ 文件引用、/ 命令补全
     // 等都由 CLI 自身在终端里渲染。
@@ -801,7 +868,14 @@ function TerminalView({
         if (disposed || wsRef.current !== socket) return;
         if (typeof e.data === "string") {
           // \x00 开头是后端控制帧，不能写进 xterm
-          if (e.data.startsWith("\x00meta:")) return;
+          if (e.data.startsWith("\x00meta:")) {
+            const grid = parseSizeMeta(e.data);
+            if (grid) {
+              effectiveGrid = grid;
+              applyLayout(false); // 仲裁结果不回报，否则两端会互相触发
+            }
+            return;
+          }
           writeOrDefer(e.data);
         } else writeOrDefer(new Uint8Array(e.data));
       };
@@ -821,11 +895,16 @@ function TerminalView({
         setBottomState(true);
         term.reset(); // 后端每次连接都回放 bounded backlog，重置避免叠加重复
         scheduleScrollToBottom();
+        // 断线期间别人的尺寸可能已经变了，先回到本端自然网格，等新的仲裁广播覆盖
+        effectiveGrid = null;
+        applyLayout(false);
+        const naturalRows = term.rows;
+        const naturalCols = term.cols;
         // 长日志只回放末尾的局部 TUI diff；改变一次尺寸再恢复，强制 PTY 补画完整画面。
         // 继续使用旧后端也认识的 resize 控制帧，避免滚动更新期间新前端把 redraw 当输入。
-        const temporaryRows = term.rows > 1 ? term.rows - 1 : term.rows + 1;
-        socket.send(`\x00resize:${temporaryRows},${term.cols}`);
-        socket.send(`\x00resize:${term.rows},${term.cols}`);
+        const temporaryRows = naturalRows > 1 ? naturalRows - 1 : naturalRows + 1;
+        socket.send(`\x00resize:${temporaryRows},${naturalCols}`);
+        socket.send(`\x00resize:${naturalRows},${naturalCols}`);
       };
       socket.onclose = (ev) => {
         if (ev.code === WS_UNAUTHORIZED) {
@@ -1121,7 +1200,16 @@ function TerminalView({
       if (Math.abs(totalDx) > 8 || Math.abs(totalDy) > 8) cancelLongPress();
       if (!tScrollStarted) {
         if (Math.abs(totalDy) < 8) return; // 等纵向位移过阈值再接管，短于此留给点按/长按
-        if (Math.abs(totalDy) < Math.abs(totalDx)) return; // 横向拖选/手势不接管
+        if (Math.abs(totalDy) < Math.abs(totalDx)) {
+          // 横向手势：仲裁网格比本端容器宽（字号已缩到下限仍装不下）时用来平移查看。
+          // touch-action:none 挡掉了原生横向滚动，只能自己搬 scrollLeft。
+          if (terminalHost.scrollWidth > terminalHost.clientWidth) {
+            terminalHost.scrollLeft -= t.clientX - tLastX;
+            tLastX = t.clientX;
+            e.preventDefault();
+          }
+          return; // 不接管纵向滚动；不可平移时留给横向拖选
+        }
         tScrollStarted = true;
       }
       // iOS WebKit 在 touch-action:none 下仍可能先形成文本选区。确认是纵向滚动后清掉
@@ -1194,12 +1282,9 @@ function TerminalView({
     const onResize = () => {
       const shouldRefocus =
         isDesktopLayout() && !!terminalHost.contains(document.activeElement);
-      fit.fit();
+      applyLayout(true);
       if (shouldRefocus) term.focus();
       scheduleScrollToBottom();
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(`\x00resize:${term.rows},${term.cols}`);
-      }
     };
     window.addEventListener("resize", onResize);
     // 容器高度变化（如折叠/展开上方详情面板）时也要 refit
@@ -1284,7 +1369,7 @@ function TerminalView({
             最新 ↓
           </button>
         )}
-        <div ref={elRef} className="dh-terminal-selectable h-full w-full overflow-hidden bg-[#131316]" />
+        <div ref={elRef} className="dh-terminal-pannable dh-terminal-selectable h-full w-full bg-[#131316]" />
       </div>
       {live && (
         <TerminalMobileComposer

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,6 +88,18 @@ body {
   padding-bottom: max(0.5rem, var(--dh-panel-safe-bottom, env(safe-area-inset-bottom)));
 }
 
+/* 多端同看时 PTY 只有一份网格（见 terminalViewport）：小屏端按仲裁网格渲染并缩小字号，
+   缩到下限仍装不下就横向平移查看，而不是把右边裁掉。纵向仍由 xterm 自己的 viewport 管。
+   滚动条隐藏：它一出现就会改 clientHeight，和「按容器算网格」互相触发反复重排。 */
+.dh-terminal-pannable {
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+.dh-terminal-pannable::-webkit-scrollbar {
+  display: none;
+}
+
 @media (pointer: coarse) {
   .dh-terminal-selectable .xterm-viewport {
     overflow-y: hidden !important;

--- a/frontend/src/terminalViewport.ts
+++ b/frontend/src/terminalViewport.ts
@@ -1,0 +1,70 @@
+/** 多端同看一个任务时的终端网格适配。
+ *
+ * PTY 只有一份 winsize，后端取所有活跃连接的最大值做仲裁（见 backend/app/terminal_viewport.py）。
+ * 客户端因此可能被要求按一个比自己容器更大的网格渲染：这时不能改 cols/rows（会与 PTY 排版
+ * 错位），而要等比缩小字号，把整幅画面塞进容器——内容完整、排版正确，只是字小。
+ *
+ * 注意：上报给后端的「期望尺寸」必须始终按**基准字号**换算，不能用缩放后的字号，
+ * 否则「字号变小 → 能塞下更多列 → 上报更大 → 仲裁更大 → 字号更小」会自激。
+ */
+
+export interface TerminalGrid {
+  cols: number;
+  rows: number;
+}
+
+export interface TerminalCellSize {
+  width: number;
+  height: number;
+}
+
+export interface TerminalBox {
+  width: number;
+  height: number;
+}
+
+/** 字号下限。低于此值实测已不可读（390px 手机塞下 200 列需要约 3px），
+ *  与其给一幅看不清的完整画面，不如停在可读字号、让超出的部分横向平移查看。 */
+export const MIN_TERMINAL_FONT_SIZE = 8;
+
+/** 容器在基准字号下天然能容纳的网格；与 FitAddon 的下限保持一致（≥2 列 / ≥1 行）。 */
+export function naturalGrid(available: TerminalBox, baseCell: TerminalCellSize): TerminalGrid | null {
+  if (!(available.width > 0 && available.height > 0)) return null;
+  if (!(baseCell.width > 0 && baseCell.height > 0)) return null;
+  return {
+    cols: Math.max(2, Math.floor(available.width / baseCell.width)),
+    rows: Math.max(1, Math.floor(available.height / baseCell.height)),
+  };
+}
+
+/** 要在容器里完整显示 effective 这个网格所需的字号；装得下就返回基准字号本身。 */
+export function fitFontSize(
+  baseFontSize: number,
+  available: TerminalBox,
+  baseCell: TerminalCellSize,
+  effective: TerminalGrid,
+): number {
+  if (!(baseFontSize > 0)) return baseFontSize;
+  if (!(available.width > 0 && available.height > 0)) return baseFontSize;
+  if (!(baseCell.width > 0 && baseCell.height > 0)) return baseFontSize;
+  if (!(effective.cols > 0 && effective.rows > 0)) return baseFontSize;
+  const ratio = Math.min(
+    available.width / (effective.cols * baseCell.width),
+    available.height / (effective.rows * baseCell.height),
+  );
+  if (ratio >= 1) return baseFontSize;
+  // 量化到 0.5px：容器尺寸每抖动一像素都换一次字号会让 xterm 反复重排。
+  const scaled = Math.floor(baseFontSize * ratio * 2) / 2;
+  return Math.max(MIN_TERMINAL_FONT_SIZE, scaled);
+}
+
+/** 解析后端广播的 "\x00meta:size:rows,cols" 控制帧；不是该帧或格式非法时返回 null。 */
+export function parseSizeMeta(frame: string): TerminalGrid | null {
+  const prefix = "\x00meta:size:";
+  if (!frame.startsWith(prefix)) return null;
+  const [rows, cols] = frame.slice(prefix.length).split(",");
+  const r = Number(rows);
+  const c = Number(cols);
+  if (!Number.isInteger(r) || !Number.isInteger(c) || r < 1 || c < 1) return null;
+  return { rows: r, cols: c };
+}

--- a/frontend/tests/terminalViewport.test.ts
+++ b/frontend/tests/terminalViewport.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  MIN_TERMINAL_FONT_SIZE,
+  fitFontSize,
+  naturalGrid,
+  parseSizeMeta,
+} from "../src/terminalViewport.ts";
+
+const CELL = { width: 7, height: 14 };
+
+test("naturalGrid 按基准字号的字元尺寸换算容器网格", () => {
+  assert.deepEqual(naturalGrid({ width: 700, height: 280 }, CELL), { cols: 100, rows: 20 });
+});
+
+test("naturalGrid 向下取整，不产生半个字元", () => {
+  assert.deepEqual(naturalGrid({ width: 703, height: 289 }, CELL), { cols: 100, rows: 20 });
+});
+
+test("naturalGrid 对退化容器返回 null", () => {
+  assert.equal(naturalGrid({ width: 0, height: 280 }, CELL), null);
+  assert.equal(naturalGrid({ width: 700, height: 0 }, CELL), null);
+  assert.equal(naturalGrid({ width: 700, height: 280 }, { width: 0, height: 14 }), null);
+});
+
+test("装得下仲裁网格时保持基准字号", () => {
+  const size = fitFontSize(12, { width: 700, height: 280 }, CELL, { cols: 100, rows: 20 });
+  assert.equal(size, 12);
+});
+
+test("容器比仲裁网格窄时按宽度比缩小字号", () => {
+  // 容器 525px 宽，被要求渲染 100 列（基准下需要 700px）→ 0.75 倍
+  const size = fitFontSize(12, { width: 525, height: 280 }, CELL, { cols: 100, rows: 20 });
+  assert.equal(size, 9);
+});
+
+test("高度不够时按高度比缩小，取两轴中更严格的那个", () => {
+  // 宽度装得下（比 1），高度只有 0.75 → 取高度这一轴
+  const size = fitFontSize(12, { width: 700, height: 210 }, CELL, { cols: 100, rows: 20 });
+  assert.equal(size, 9);
+});
+
+test("字号量化到 0.5px，避免容器抖动引发反复重排", () => {
+  const size = fitFontSize(12, { width: 690, height: 280 }, CELL, { cols: 100, rows: 20 });
+  assert.equal(size, 11.5);
+});
+
+test("再小也不缩到不可读以下——超出部分留给横向平移", () => {
+  const size = fitFontSize(12, { width: 40, height: 280 }, CELL, { cols: 100, rows: 20 });
+  assert.equal(size, MIN_TERMINAL_FONT_SIZE);
+  assert.ok(size > 0);
+});
+
+test("手机端塞桌面端网格时停在可读下限，而不是缩到看不清", () => {
+  // 390px 手机 vs 164 列桌面网格：等比需要约 3px，实测不可读，停在下限
+  const size = fitFontSize(12, { width: 390, height: 300 }, CELL, { cols: 164, rows: 21 });
+  assert.equal(size, MIN_TERMINAL_FONT_SIZE);
+});
+
+test("退化输入回退到基准字号而不是 NaN", () => {
+  assert.equal(fitFontSize(12, { width: 0, height: 0 }, CELL, { cols: 100, rows: 20 }), 12);
+  assert.equal(fitFontSize(12, { width: 700, height: 280 }, CELL, { cols: 0, rows: 20 }), 12);
+});
+
+test("parseSizeMeta 解析尺寸广播帧", () => {
+  assert.deepEqual(parseSizeMeta("\x00meta:size:40,200"), { rows: 40, cols: 200 });
+});
+
+test("parseSizeMeta 拒绝其它 meta 帧与畸形值", () => {
+  assert.equal(parseSizeMeta("\x00meta:backlog_truncated"), null);
+  assert.equal(parseSizeMeta("\x00meta:size:40"), null);
+  assert.equal(parseSizeMeta("\x00meta:size:abc,200"), null);
+  assert.equal(parseSizeMeta("\x00meta:size:0,200"), null);
+  assert.equal(parseSizeMeta("\x00meta:size:1.5,200"), null);
+});


### PR DESCRIPTION
## 问题

手机和电脑同时打开同一个任务的终端详情，手机端一连上/一输入，电脑端的终端就被重排成手机宽度。

根因不是样式：一个任务只有一个子进程、一个 PTY，PTY 只有一份 winsize（`pty_session.py:802`）。`ws.py` 之前对任何客户端发来的 `\x00resize:` 帧都直接 `session.resize()`，最后一个说话的人决定所有人的排版。

## 改动

按连接记录各自期望的尺寸，PTY 取所有活跃连接的**最大值**，并把仲裁结果以 `\x00meta:size:rows,cols` 广播回各端：

- **大屏端**：永远按自己的宽度渲染，不再被小屏端压窄
- **小屏端**：按仲裁网格渲染并等比缩小字号；缩到可读下限（8px）仍装不下的部分改为**横向平移**查看，而不是被裁掉
- **小屏端单独连接时**：最大值就是它自己，体验与现在完全一致
- **最宽的客户端断开后**：PTY 缩回剩余连接的尺寸并广播

设计上无法做到「每个连接各自一个尺寸」——服务端发出去的已经是排好版的字符网格，不是可重排的结构化数据；tmux 遇到大小不同的客户端同样只有「取最小」或「大屏为准、小屏平移」两条路。

### 文件

| 文件 | 作用 |
|---|---|
| `backend/app/terminal_viewport.py` | 尺寸仲裁注册表（新增） |
| `backend/app/routers/ws.py` | 按连接登记尺寸、广播 size 帧 |
| `frontend/src/terminalViewport.ts` | 自然网格与字号换算（新增） |
| `frontend/src/components/TerminalPanel.tsx` | 按仲裁网格渲染 + 横向平移手势 |
| `frontend/src/index.css` | 终端宿主容器可横向平移 |

两个实现要点：
- 广播帧走各连接自己的出站队列，而不是直接 `send`——每个连接只有 `pump_out` 一个发送方，避免与正在发送的终端字节流并发写同一个 WebSocket 而交错帧。
- 前端上报的「期望尺寸」一律按**基准字号**换算，不能用缩放后的字号，否则「字变小 → 塞得下更多列 → 上报更大 → 仲裁更大 → 字更小」会自激。

`\x00meta:` 前缀的控制帧现有前端本来就会丢弃，旧前端 + 新后端不会把它写进 xterm。

## 验证

**1. 行为回归（改动前后对照，同一段脚本）**

```
改动前：PTY 最终尺寸 (20, 45)   ← 电脑端被手机端压窄
改动后：PTY 尺寸序列 [(40,200), (40,200)]，最终 (40, 200)   ← 不受影响
```

**2. 单元 + 集成测试**

- `backend/tests/test_terminal_viewport.py` 12 例（仲裁、断开回缩、任务隔离、畸形尺寸拒绝且不污染状态）
- `backend/tests/test_ws_viewport.py` 5 例（双 WebSocket 真实连接：手机端不压窄电脑端、电脑端断开后回缩、单端仍用自己尺寸、畸形帧不被当作输入打进 PTY、全部断开后注册表清空）
- `frontend/tests/terminalViewport.test.ts` 16 例（网格换算、两轴取严、0.5px 量化、可读下限、meta 帧解析）

```
backend:  105 passed, 1 failed
frontend: 16 pass, 0 fail
tsc -b --force: OK
vite build: ✓ built in 1.85s
```

唯一失败是 `test_browser_computer.py::test_runs_computer_loop_and_persists_screenshot`，原因 `BrowserType.launch: Executable doesn't exist`（playwright 浏览器未下载），**与本次改动无关的既有环境失败**。

**3. 真实浏览器实测**（Chrome，加载真实 xterm + FitAddon + 本 PR 的 `terminalViewport.ts`）

| 容器 | 自然网格 | 被要求渲染 | 结果字号 | 内容宽度 | 结论 |
|---|---|---|---|---|---|
| 1200×300 | 164 列 | 200 列 | 9.5px | 1144px | 完整显示含右框线，无需平移 |
| 390×300 | 51 列 | 200 列 | 8px（下限） | 963px | 不裁切，`scrollWidth 963 > clientWidth 390`，可平移至最右端（`scrollLeft` 达 573）|

同时确认 FitAddon 依赖的字元尺寸私有 API 在真实浏览器可用（实测 7.22×14px）；取不到时代码回退到原有 `fit.fit()` 行为，不会崩。

## 未验证 / 已知取舍

- **未做真机双端联调**：需要一个真实运行中的 CLI 任务 + 两台设备，本轮以「WS 层双连接集成测试 + 浏览器双容器实测」覆盖，端到端两台设备的手感请你实际试一下。
- **极端宽度差下小屏端仍需横向滑动**：390px 手机对 164 列桌面网格，等比只需约 3px 字号，实测不可读，因此停在 8px 下限 + 平移。`MIN_TERMINAL_FONT_SIZE`（`frontend/src/terminalViewport.ts`）是单个常量，觉得该更小/更大直接调。