### PR TITLE
feat: 终端里双击文件可预览，图片/文本/PDF 直接看

### DIFF
--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, File, HTTPException, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
-from .. import auth, browser_computer, db, events, log_archive, nesting, orchestrations, routing, scheduler, sessions, subtasks, uploads
+from .. import auth, browser_computer, db, events, log_archive, nesting, orchestrations, routing, scheduler, sessions, subtasks, task_files, uploads
 from ..engines import CODING_ENGINES, ENGINES, normalize_engine_id
 from ..pty_session import remove_terminal_log_files, script_log_path_for
 
@@ -840,6 +840,42 @@ def get_browser_asset(task_id: int, asset_id: str):
     if not path.is_file():
         raise HTTPException(404, "截图不存在")
     return FileResponse(path, media_type="image/png", filename=asset_id)
+
+
+@router.get("/{task_id}/file")
+def get_task_file(task_id: int, path: str, download: bool = False):
+    """预览/下载终端里双击到的文件。
+
+    远程（手机）访问走的就是这个接口——源文件由后端代读，前端只拿字节流，
+    不需要客户端能访问那台机器的文件系统。
+    """
+    row = db.query_one(
+        "SELECT p.path AS root FROM task t JOIN project p ON p.id=t.project_id "
+        "WHERE t.id=? AND t.deleted=0",
+        (task_id,),
+    )
+    if row is None:
+        raise HTTPException(404, "任务不存在")
+    try:
+        target = task_files.resolve_task_file(Path(row["root"]), path)
+    except task_files.TaskFileError as exc:
+        raise HTTPException(exc.status, exc.message) from exc
+
+    kind = task_files.preview_kind(target)
+    as_attachment = download or kind == "binary"
+    return FileResponse(
+        target,
+        media_type=task_files.response_media_type(target, kind),
+        filename=target.name if as_attachment else None,
+        headers={
+            "X-Preview-Kind": kind,
+            "X-Content-Type-Options": "nosniff",
+            # 直接在浏览器地址栏打开这个 URL 时也不给它执行脚本/发请求的能力：
+            # 这些文件正是 agent 刚写进工作目录的，不能当作可信内容。
+            "Content-Security-Policy": "default-src 'none'; img-src 'self' data:; sandbox",
+            "Cache-Control": "no-store",
+        },
+    )
 
 
 @router.delete("/{task_id}")

--- a/backend/app/task_files.py
+++ b/backend/app/task_files.py
@@ -1,0 +1,101 @@
+"""终端里双击文件时的预览取文件：路径解析与类型判定。
+
+终端输出里的路径是**模型和命令行打印出来的任意字符串**，等于外部输入：远程访问时
+一条 `cat /etc/passwd` 的回显就能变成一个可点的读文件请求。因此这里只放行任务自己
+工作目录内的文件，且以 realpath 为准——软链接指向目录外同样拒绝。
+"""
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+
+# 预览用途的单文件上限：再大就不是"看一眼"了，也别把内存喂给一次误点
+MAX_PREVIEW_BYTES = 25 * 1024 * 1024
+
+PreviewKind = str  # "image" | "pdf" | "text" | "binary"
+
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".avif", ".bmp", ".ico"}
+_TEXT_EXTS = {
+    ".txt", ".md", ".markdown", ".rst", ".log", ".json", ".jsonl", ".yaml", ".yml",
+    ".toml", ".ini", ".cfg", ".conf", ".env", ".csv", ".tsv", ".xml", ".html", ".htm",
+    ".css", ".scss", ".less", ".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".py",
+    ".rb", ".go", ".rs", ".java", ".kt", ".swift", ".c", ".h", ".cc", ".cpp", ".hpp",
+    ".m", ".mm", ".sh", ".bash", ".zsh", ".fish", ".sql", ".diff", ".patch", ".lock",
+    ".gradle", ".properties", ".tf", ".proto", ".graphql", ".vue", ".svelte",
+}
+# 常见的无扩展名文本文件
+_TEXT_NAMES = {
+    "dockerfile", "makefile", "license", "licence", "readme", "changelog", "notice",
+    "procfile", "caddyfile", "justfile", "rakefile", "gemfile", "brewfile",
+    ".gitignore", ".gitattributes", ".dockerignore", ".editorconfig", ".npmrc",
+    ".nvmrc", ".prettierrc", ".eslintrc", ".env",
+}
+
+
+class TaskFileError(Exception):
+    """带 HTTP 状态码的取文件失败；路由层原样转成 HTTPException。"""
+
+    def __init__(self, status: int, message: str):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def resolve_task_file(root: Path, requested: str) -> Path:
+    """把终端里点到的路径解析成工作目录内的真实文件；越界/不存在/过大都抛 TaskFileError。"""
+    text = (requested or "").strip()
+    if not text:
+        raise TaskFileError(400, "路径为空")
+
+    root = root.resolve()
+    candidate = Path(text).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError as exc:  # 循环软链接等
+        raise TaskFileError(400, "路径无法解析") from exc
+
+    # 用 relative_to 而不是字符串前缀：/work-secrets 与 /work 前缀相同但不是子目录。
+    # resolve() 已展开软链接，所以指向目录外的链接在这里就会被拦下。
+    if resolved != root and root not in resolved.parents:
+        raise TaskFileError(403, "只能预览任务工作目录内的文件")
+    if not resolved.is_file():
+        raise TaskFileError(404, "文件不存在")
+    if resolved.stat().st_size > MAX_PREVIEW_BYTES:
+        raise TaskFileError(413, "文件过大，无法预览")
+    return resolved
+
+
+def preview_kind(path: Path) -> PreviewKind:
+    """按扩展名判定前端该用哪种方式展示。"""
+    suffix = path.suffix.lower()
+    if suffix in _IMAGE_EXTS:
+        return "image"
+    if suffix == ".pdf":
+        return "pdf"
+    if suffix in _TEXT_EXTS:
+        return "text"
+    if not suffix and path.name.lower() in _TEXT_NAMES:
+        return "text"
+    if suffix and path.name.lower() in _TEXT_NAMES:  # .gitignore 之类，suffix 即全名
+        return "text"
+    return "binary"
+
+
+def response_media_type(path: Path, kind: PreviewKind) -> str:
+    """响应用的 Content-Type。
+
+    文本一律按 text/plain 返回：.html/.svg 若按自身 MIME 内联返回，就是在应用同源下
+    执行任务目录里的任意脚本——而那些文件正是 agent 刚写出来的。
+    """
+    if kind == "text":
+        return "text/plain; charset=utf-8"
+    if kind == "pdf":
+        return "application/pdf"
+    if kind == "image":
+        guessed, _ = mimetypes.guess_type(path.name)
+        if guessed and guessed.startswith("image/"):
+            return guessed
+        return "application/octet-stream"
+    return "application/octet-stream"

--- a/backend/tests/test_task_file_route.py
+++ b/backend/tests/test_task_file_route.py
@@ -1,0 +1,87 @@
+"""GET /api/tasks/{id}/file：终端里双击文件后的取文件接口。"""
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.app.routers import tasks as tasks_router
+
+
+class TaskFileRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name).resolve()
+        (self.root / "shot.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (self.root / "notes.md").write_text("# 标题\n正文\n", encoding="utf-8")
+        (self.root / "page.html").write_text("<script>alert(1)</script>", encoding="utf-8")
+        (self.root / "bundle.zip").write_bytes(b"PK\x03\x04")
+
+        app = FastAPI()
+        app.include_router(tasks_router.router)
+        self.client = TestClient(app)
+        patcher = patch.object(
+            tasks_router.db, "query_one", return_value={"root": str(self.root)}
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def get(self, path: str, **params):
+        return self.client.get(f"/api/tasks/1/file", params={"path": path, **params})
+
+    def test_image_is_served_with_its_own_type_and_kind(self):
+        res = self.get("shot.png")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["X-Preview-Kind"], "image")
+        self.assertEqual(res.headers["content-type"], "image/png")
+        self.assertEqual(res.content, b"\x89PNG\r\n\x1a\n")
+
+    def test_text_is_served_as_utf8_plain_text(self):
+        res = self.get("notes.md")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["X-Preview-Kind"], "text")
+        self.assertEqual(res.headers["content-type"], "text/plain; charset=utf-8")
+        self.assertIn("标题", res.text)
+
+    def test_html_is_never_served_as_html(self):
+        # 否则任务目录里 agent 刚写的 html 会在应用同源下执行
+        res = self.get("page.html")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["content-type"], "text/plain; charset=utf-8")
+        self.assertEqual(res.headers["X-Content-Type-Options"], "nosniff")
+        self.assertIn("sandbox", res.headers["Content-Security-Policy"])
+
+    def test_binary_is_forced_to_download(self):
+        res = self.get("bundle.zip")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers["X-Preview-Kind"], "binary")
+        self.assertIn("attachment", res.headers["content-disposition"])
+
+    def test_download_flag_forces_attachment_for_previewable_types(self):
+        res = self.get("shot.png", download="true")
+        self.assertIn("attachment", res.headers["content-disposition"])
+
+    def test_previewable_types_are_inline_by_default(self):
+        self.assertNotIn("content-disposition", self.get("shot.png").headers)
+
+    def test_path_outside_workdir_is_refused(self):
+        res = self.get("/etc/passwd")
+        self.assertEqual(res.status_code, 403)
+
+    def test_dot_dot_escape_is_refused(self):
+        res = self.get("../../etc/passwd")
+        self.assertEqual(res.status_code, 403)
+
+    def test_missing_file_is_404(self):
+        self.assertEqual(self.get("nope.txt").status_code, 404)
+
+    def test_unknown_task_is_404(self):
+        with patch.object(tasks_router.db, "query_one", return_value=None):
+            self.assertEqual(self.get("notes.md").status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_task_files.py
+++ b/backend/tests/test_task_files.py
@@ -1,0 +1,127 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from backend.app.task_files import (
+    MAX_PREVIEW_BYTES,
+    TaskFileError,
+    preview_kind,
+    resolve_task_file,
+    response_media_type,
+)
+
+
+class ResolveTaskFileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name).resolve()
+        (self.root / "sub").mkdir()
+        (self.root / "sub" / "shot.png").write_bytes(b"\x89PNG\r\n")
+        (self.root / "notes.md").write_text("hi")
+
+    def test_relative_path_resolves_under_root(self):
+        self.assertEqual(resolve_task_file(self.root, "sub/shot.png"), self.root / "sub" / "shot.png")
+
+    def test_dot_slash_prefix_is_accepted(self):
+        self.assertEqual(resolve_task_file(self.root, "./notes.md"), self.root / "notes.md")
+
+    def test_absolute_path_inside_root_is_accepted(self):
+        target = str(self.root / "notes.md")
+        self.assertEqual(resolve_task_file(self.root, target), self.root / "notes.md")
+
+    def test_absolute_path_outside_root_is_refused(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "/etc/passwd")
+        self.assertEqual(ctx.exception.status, 403)
+
+    def test_dot_dot_escape_is_refused(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "../../etc/passwd")
+        self.assertEqual(ctx.exception.status, 403)
+
+    def test_symlink_pointing_outside_root_is_refused(self):
+        outside = Path(self.tmp.name).resolve().parent / "bosun-test-outside.txt"
+        outside.write_text("secret")
+        self.addCleanup(outside.unlink)
+        link = self.root / "escape.txt"
+        link.symlink_to(outside)
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "escape.txt")
+        self.assertEqual(ctx.exception.status, 403)
+
+    def test_missing_file_is_404(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "nope.txt")
+        self.assertEqual(ctx.exception.status, 404)
+
+    def test_directory_is_not_a_file(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "sub")
+        self.assertEqual(ctx.exception.status, 404)
+
+    def test_empty_path_is_rejected(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "   ")
+        self.assertEqual(ctx.exception.status, 400)
+
+    def test_oversized_file_is_refused(self):
+        big = self.root / "big.bin"
+        big.write_bytes(b"0" * (MAX_PREVIEW_BYTES + 1))
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, "big.bin")
+        self.assertEqual(ctx.exception.status, 413)
+
+    def test_root_itself_is_refused_as_a_file(self):
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, ".")
+        self.assertEqual(ctx.exception.status, 404)
+
+    def test_sibling_directory_with_shared_prefix_is_refused(self):
+        # /work 与 /work-secrets 前缀相同但不是子目录，纯字符串前缀判断会漏
+        sibling = self.root.parent / (self.root.name + "-secrets")
+        sibling.mkdir()
+        leak = sibling / "key.txt"
+        leak.write_text("secret")
+        self.addCleanup(lambda: (leak.unlink(), sibling.rmdir()))
+        with self.assertRaises(TaskFileError) as ctx:
+            resolve_task_file(self.root, str(leak))
+        self.assertEqual(ctx.exception.status, 403)
+
+
+class PreviewKindTest(unittest.TestCase):
+    def test_images(self):
+        for name in ("a.png", "a.JPG", "a.jpeg", "a.gif", "a.webp", "a.svg", "a.avif"):
+            self.assertEqual(preview_kind(Path(name)), "image", name)
+
+    def test_pdf(self):
+        self.assertEqual(preview_kind(Path("report.pdf")), "pdf")
+
+    def test_text_like(self):
+        for name in ("a.md", "a.json", "a.log", "a.py", "a.tsx", "a.yaml", "a.csv", "a.txt"):
+            self.assertEqual(preview_kind(Path(name)), "text", name)
+
+    def test_extensionless_known_names_are_text(self):
+        for name in ("Dockerfile", "Makefile", ".gitignore", "LICENSE"):
+            self.assertEqual(preview_kind(Path(name)), "text", name)
+
+    def test_unknown_falls_back_to_binary(self):
+        for name in ("a.zip", "a.bin", "a.mysteryext"):
+            self.assertEqual(preview_kind(Path(name)), "binary", name)
+
+    def test_text_like_files_are_served_as_plain_text(self):
+        # .html/.svg 若按自身 MIME 内联返回，等于在应用同源下执行任意脚本
+        self.assertEqual(response_media_type(Path("page.html"), "text"), "text/plain; charset=utf-8")
+
+    def test_images_keep_their_own_media_type(self):
+        self.assertEqual(response_media_type(Path("a.png"), "image"), "image/png")
+
+    def test_pdf_keeps_its_media_type(self):
+        self.assertEqual(response_media_type(Path("a.pdf"), "pdf"), "application/pdf")
+
+    def test_binary_is_octet_stream(self):
+        self.assertEqual(response_media_type(Path("a.zip"), "binary"), "application/octet-stream")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,6 +13,9 @@ import type {
   Task,
 } from "./types";
 
+export type TaskFileKind = "image" | "pdf" | "text" | "binary";
+export type TaskFilePayload = { kind: TaskFileKind; blob: Blob };
+
 export type AppSettings = {
   max_concurrent: number;
   /** 打开工作台（URL 无 hash）时进入的页面 */
@@ -283,6 +286,18 @@ function fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> 
   });
 }
 
+/** FastAPI 的错误体是 {"detail": "..."}；取出人话，取不到就退回状态文本。 */
+async function detail(res: Response): Promise<string> {
+  const text = await res.text().catch(() => "");
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed.detail === "string") return parsed.detail;
+  } catch {
+    // 不是 JSON，按原文用
+  }
+  return text || res.statusText;
+}
+
 async function j<T>(res: Response): Promise<T> {
   if (!res.ok) throw new Error((await res.text()) || res.statusText);
   return res.json();
@@ -327,6 +342,15 @@ export const api = {
   tasks: (projectId?: number) =>
     fetch(projectId == null ? "/api/tasks" : `/api/tasks?project_id=${projectId}`).then((r) => j<Task[]>(r)),
   getTask: (id: number) => fetch(`/api/tasks/${id}`).then((r) => j<Task>(r)),
+  /** 终端里双击到的文件。后端按任务工作目录校验后代读，所以手机远程访问也能预览。 */
+  taskFile: async (id: number, path: string): Promise<TaskFilePayload> => {
+    const res = await fetch(`/api/tasks/${id}/file?path=${encodeURIComponent(path)}`);
+    if (!res.ok) throw new Error(await detail(res));
+    return {
+      kind: (res.headers.get("X-Preview-Kind") ?? "binary") as TaskFileKind,
+      blob: await res.blob(),
+    };
+  },
   updateTask: (id: number, body: { title?: string; prompt?: string; engine?: Engine }) =>
     write<Task>("PUT", `/api/tasks/${id}`, body),
   getLog: (id: number, source: "auto" | "terminal" | "script" = "auto") =>

--- a/frontend/src/components/FilePreviewOverlay.tsx
+++ b/frontend/src/components/FilePreviewOverlay.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+
+import { api, type TaskFileKind } from "../api";
+
+type Loaded = { kind: TaskFileKind; url: string; text: string | null; size: number };
+
+const KIND_LABEL: Record<TaskFileKind, string> = {
+  image: "图片",
+  pdf: "PDF",
+  text: "文本",
+  binary: "二进制文件",
+};
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+/** 终端里双击文件后的预览弹层。文件由后端代读，手机远程访问走的是同一条路径。 */
+export function FilePreviewOverlay({
+  taskId,
+  path,
+  onClose,
+}: {
+  taskId: number;
+  path: string;
+  onClose: () => void;
+}) {
+  const [loaded, setLoaded] = useState<Loaded | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    let objectUrl: string | null = null;
+    setLoaded(null);
+    setError(null);
+    api
+      .taskFile(taskId, path)
+      .then(async ({ kind, blob }) => {
+        if (disposed) return;
+        // 文本自己读出来渲染，不交给浏览器解析——.html/.svg 内联渲染等于在应用同源下执行它
+        const text = kind === "text" ? await blob.text() : null;
+        if (disposed) return;
+        objectUrl = URL.createObjectURL(blob);
+        setLoaded({ kind, url: objectUrl, text, size: blob.size });
+      })
+      .catch((e: unknown) => {
+        if (!disposed) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      disposed = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [taskId, path]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const name = path.split("/").pop() || path;
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 px-3 pt-[max(0.75rem,env(safe-area-inset-top))] pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-full w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-dh-bsoft bg-dh-surface shadow-xl shadow-black/50 ring-1 ring-inset ring-white/[0.04]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 border-b border-dh-bsoft px-4 py-2.5">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-dh-text" title={path}>
+              {name}
+            </div>
+            <div className="truncate text-[11px] text-dh-muted" title={path}>
+              {path}
+              {loaded && ` · ${KIND_LABEL[loaded.kind]} · ${formatSize(loaded.size)}`}
+            </div>
+          </div>
+          {loaded && (
+            <a
+              href={loaded.url}
+              download={name}
+              className="shrink-0 rounded-md border border-dh-border bg-dh-s2 px-2.5 py-1 text-xs text-slate-100 hover:bg-dh-hover"
+            >
+              下载
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-md px-2 py-1 text-sm text-dh-muted hover:bg-dh-hover hover:text-slate-50"
+            title="关闭（Esc）"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-dh-soft">
+          {error && (
+            <div className="px-4 py-8 text-center text-sm text-rose-300">{error}</div>
+          )}
+          {!error && !loaded && (
+            <div className="px-4 py-8 text-center text-sm text-dh-muted">加载中…</div>
+          )}
+          {loaded?.kind === "image" && (
+            <div className="flex min-h-[8rem] items-center justify-center p-3">
+              <img src={loaded.url} alt={name} className="max-h-[70vh] max-w-full object-contain" />
+            </div>
+          )}
+          {loaded?.kind === "pdf" && (
+            <iframe src={loaded.url} title={name} className="h-[70vh] w-full border-0 bg-dh-bg" />
+          )}
+          {loaded?.kind === "text" && (
+            <pre className="max-h-[70vh] overflow-auto px-4 py-3 text-[12px] leading-5 text-dh-tsoft">
+              {loaded.text}
+            </pre>
+          )}
+          {loaded?.kind === "binary" && (
+            <div className="px-4 py-8 text-center text-sm text-dh-muted">
+              这个类型无法预览，用上方「下载」保存到本地。
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -22,6 +22,8 @@ import { confirmDialog, promptDialog, toast } from "../overlay";
 import { guardQuota } from "../quota";
 import { TERMINAL_SUBMIT_KEY } from "../terminalInput";
 import { installHardWrappedWebLinkProvider } from "../terminalLinks";
+import { extractPathAt } from "../terminalFilePaths";
+import { FilePreviewOverlay } from "./FilePreviewOverlay";
 import { STATUS_STYLE, taskStatusStyleKey } from "../theme";
 import type { Engine, Task } from "../types";
 import { useSingleFlight } from "../useSingleFlight";
@@ -371,6 +373,8 @@ function TerminalView({
   const [disconnected, setDisconnected] = useState(false);
   const [connected, setConnected] = useState(false);
   const [pastingImages, setPastingImages] = useState(false);
+  // 终端里双击到的文件路径（双击/双指轻点两下），非空即弹预览
+  const [previewPath, setPreviewPath] = useState<string | null>(null);
   // 后端回放前发 \x00meta:backlog_truncated：日志超出回放预算，只回放了最近输出
   // 移动端长按选区已就绪：浮出「复制」按钮。WebKit 对 touchend 手势的剪贴板授权不可靠
   // （实测 execCommand/writeText 均可能失败），click 手势才稳，所以松手不自动复制。
@@ -1025,12 +1029,9 @@ function TerminalView({
       typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
         ? new Intl.Segmenter(undefined, { granularity: "word" })
         : null;
-    const startWordSelection = () => {
-      tLongPressTimer = null;
-      if (!tActive || tScrollStarted) return;
-      const { col, row } = cellFromTouch(tLastX, tLastY);
-      // 逐 cell 收集字符簇并记录列号：中文等宽字符占两列，translateToString 的字符串
-      // 下标≠列号，直接拿列号当下标会选错位置。
+    // 逐 cell 收集字符簇并记录列号：中文等宽字符占两列，translateToString 的字符串
+    // 下标≠列号，直接拿列号当下标会定位错。双击取路径与长按选词都靠它。
+    const readLineClusters = (row: number) => {
       const line = term.buffer.active.getLine(row);
       const clusters: { chars: string; col: number; width: number }[] = [];
       for (let x = 0; line && x < term.cols; ) {
@@ -1040,6 +1041,14 @@ function TerminalView({
         clusters.push({ chars: cell.getChars() || " ", col: x, width });
         x += width;
       }
+      return clusters;
+    };
+
+    const startWordSelection = () => {
+      tLongPressTimer = null;
+      if (!tActive || tScrollStarted) return;
+      const { col, row } = cellFromTouch(tLastX, tLastY);
+      const clusters = readLineClusters(row);
       const offsets: number[] = [];
       let acc = 0;
       for (const cluster of clusters) {
@@ -1080,6 +1089,50 @@ function TerminalView({
       const from = Math.min(idx, tSelectAnchorIdx);
       term.select(from % term.cols, Math.floor(from / term.cols), Math.abs(idx - tSelectAnchorIdx) + 1);
     };
+    // 路径可能被软换行拆到下一行，最多向后拼这么多行再找
+    const MAX_WRAPPED_PATH_ROWS = 6;
+    /** 取出某个 cell 上的文件路径；点在空白处或那段文本不像路径时返回 null。 */
+    const pathAtCell = (row: number, col: number): string | null => {
+      const buffer = term.buffer.active;
+      let startRow = row;
+      // 点在续行上时先回到这条逻辑行的开头，否则路径的前半截会丢
+      for (let n = 0; n < MAX_WRAPPED_PATH_ROWS && startRow > 0; n += 1) {
+        if (!buffer.getLine(startRow)?.isWrapped) break;
+        startRow -= 1;
+      }
+      const rows = [startRow];
+      while (rows.length < MAX_WRAPPED_PATH_ROWS && buffer.getLine(rows[rows.length - 1] + 1)?.isWrapped) {
+        rows.push(rows[rows.length - 1] + 1);
+      }
+      let text = "";
+      let clickIndex = -1;
+      for (const r of rows) {
+        const clusters = readLineClusters(r);
+        if (r === row) {
+          const ci = clusters.findIndex((c) => col >= c.col && col < c.col + c.width);
+          if (ci < 0) return null;
+          clickIndex = text.length + clusters.slice(0, ci).reduce((acc, c) => acc + c.chars.length, 0);
+        }
+        text += clusters.map((c) => c.chars).join("");
+      }
+      if (clickIndex < 0) return null;
+      return extractPathAt(text, clickIndex);
+    };
+    const openPathAt = (clientX: number, clientY: number): boolean => {
+      const { col, row } = cellFromTouch(clientX, clientY);
+      const path = pathAtCell(row, col);
+      if (path) setPreviewPath(path);
+      return path !== null;
+    };
+    const onDoubleClick = (e: MouseEvent) => {
+      // 命中路径才拦：没命中就把双击留给 xterm 的选词
+      if (openPathAt(e.clientX, e.clientY)) e.preventDefault();
+    };
+    // 双击轻点：iOS 上合成 dblclick 不可靠（mousedown 已被拦），自己按间隔+位移判定
+    let lastTapAt = 0;
+    let lastTapX = 0;
+    let lastTapY = 0;
+
     const onTouchStart = (e: globalThis.TouchEvent) => {
       if (e.touches.length !== 1) {
         cancelLongPress();
@@ -1163,6 +1216,21 @@ function TerminalView({
         // 有选区时轻点＝取消选区（对应原生选区点击空白收起的习惯）
         term.clearSelection();
       }
+      if (tapLike) {
+        const tappedAt = performance.now();
+        const isDoubleTap =
+          tappedAt - lastTapAt < 320 &&
+          Math.abs(tLastX - lastTapX) < 24 &&
+          Math.abs(tLastY - lastTapY) < 24;
+        if (isDoubleTap) {
+          lastTapAt = 0; // 三连点不再触发第二次
+          openPathAt(tLastX, tLastY);
+        } else {
+          lastTapAt = tappedAt;
+          lastTapX = tLastX;
+          lastTapY = tLastY;
+        }
+      }
       if (selectionResumeTimer != null) window.clearTimeout(selectionResumeTimer);
       selectionResumeTimer = window.setTimeout(() => {
         selectionResumeTimer = null;
@@ -1172,6 +1240,7 @@ function TerminalView({
     const touchCaptureOptions = { capture: true, passive: false } as AddEventListenerOptions;
     const touchEndCaptureOptions = { capture: true, passive: true } as AddEventListenerOptions;
     terminalHost.addEventListener("pointerdown", focusTerminal);
+    terminalHost.addEventListener("dblclick", onDoubleClick);
     // xterm 会先在内部 viewport 处理滚轮/翻页键并同步触发 onScroll。如果等事件冒泡到
     // terminalHost 才标记，onScroll 看不到“用户滚动”，下一帧的新输出仍会把视图拉回底部。
     // 捕获阶段先记录意图，实际离开底部后 onScroll 就会关闭自动跟随。
@@ -1217,6 +1286,7 @@ function TerminalView({
       copySelectionRef.current = null;
       ro.disconnect();
       terminalHost.removeEventListener("pointerdown", focusTerminal);
+      terminalHost.removeEventListener("dblclick", onDoubleClick);
       terminalHost.removeEventListener("copy", onTerminalCopy);
       terminalHost.removeEventListener("paste", onTerminalPaste, true);
       terminalHost.removeEventListener("wheel", markUserScroll, userScrollCaptureOptions);
@@ -1286,6 +1356,13 @@ function TerminalView({
         )}
         <div ref={elRef} className="dh-terminal-selectable h-full w-full overflow-hidden bg-[#131316]" />
       </div>
+      {previewPath !== null && (
+        <FilePreviewOverlay
+          taskId={taskId}
+          path={previewPath}
+          onClose={() => setPreviewPath(null)}
+        />
+      )}
       {live && (
         <TerminalMobileComposer
           taskId={taskId}

--- a/frontend/src/terminalFilePaths.ts
+++ b/frontend/src/terminalFilePaths.ts
@@ -1,0 +1,61 @@
+/** 从终端某一行的某一列取出被双击到的文件路径。
+ *
+ * 终端里的路径是命令行/模型打印出来的任意字符串，这里只负责「取出用户点的那一段」，
+ * 是否允许读取由后端按任务工作目录判定（见 backend/app/task_files.py）。
+ */
+
+/** 路径 token 的边界：空白、引号、以及 TUI 常用的竖线框线。 */
+const BOUNDARY = /[\s"'`|│┃║]/;
+/** 成对包裹符：点在里面时整段取出（这样带空格的路径也能取全）。 */
+const QUOTES = ['"', "'"];
+const LEADING_TRIM = /^[([{<]+/;
+const TRAILING_TRIM = /[)\]}>,;.:!?、，。；：]+$/;
+/** 编译器/栈回溯常见的 path:line 或 path:line:col 后缀。 */
+const LINE_COL_SUFFIX = /:\d+(?::\d+)?$/;
+
+function quotedSpanAt(line: string, column: number): string | null {
+  for (const quote of QUOTES) {
+    let from = line.indexOf(quote);
+    while (from !== -1) {
+      const to = line.indexOf(quote, from + 1);
+      if (to === -1) break;
+      if (column > from && column < to) return line.slice(from + 1, to);
+      from = line.indexOf(quote, to + 1);
+    }
+  }
+  return null;
+}
+
+function tidy(raw: string): string {
+  let text = raw.replace(LEADING_TRIM, "").replace(TRAILING_TRIM, "");
+  text = text.replace(LINE_COL_SUFFIX, "");
+  return text.replace(TRAILING_TRIM, "");
+}
+
+function looksLikePath(text: string): boolean {
+  if (!text) return false;
+  // http(s):// 交给已有的链接处理，别当本地文件读
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(text)) return false;
+  return text.includes("/") || /\.[A-Za-z0-9]+$/.test(text);
+}
+
+/** 返回该列上的文件路径；点在空白处、或那段文本不像路径时返回 null。 */
+export function extractPathAt(line: string, column: number): string | null {
+  if (column < 0 || column >= line.length) return null;
+  const char = line[column];
+  if (char === undefined || BOUNDARY.test(char)) return null;
+
+  const quoted = quotedSpanAt(line, column);
+  if (quoted !== null) {
+    const text = quoted.trim();
+    return looksLikePath(text) ? text : null;
+  }
+
+  let start = column;
+  while (start > 0 && !BOUNDARY.test(line[start - 1] as string)) start -= 1;
+  let end = column;
+  while (end + 1 < line.length && !BOUNDARY.test(line[end + 1] as string)) end += 1;
+
+  const text = tidy(line.slice(start, end + 1));
+  return looksLikePath(text) ? text : null;
+}

--- a/frontend/tests/terminalFilePaths.test.ts
+++ b/frontend/tests/terminalFilePaths.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { extractPathAt } from "../src/terminalFilePaths.ts";
+
+const at = (line: string, marker: string) => {
+  const index = line.indexOf(marker);
+  assert.ok(index >= 0, `marker ${marker} not in line`);
+  return index;
+};
+
+test("从普通输出里取出相对路径", () => {
+  const line = "  已写入 docs/design/notes.md 共 42 行";
+  assert.equal(extractPathAt(line, at(line, "docs/")), "docs/design/notes.md");
+});
+
+test("从任意一列点进去都取到同一个路径", () => {
+  const line = "wrote src/components/App.tsx";
+  const start = at(line, "src/");
+  for (let i = start; i < start + "src/components/App.tsx".length; i += 1) {
+    assert.equal(extractPathAt(line, i), "src/components/App.tsx");
+  }
+});
+
+test("绝对路径", () => {
+  const line = "saved to /Users/me/proj/out/shot.png";
+  assert.equal(extractPathAt(line, at(line, "/Users")), "/Users/me/proj/out/shot.png");
+});
+
+test("剥掉编译器输出的 :行:列 后缀", () => {
+  const line = "src/app.ts:120:8 - error TS2345";
+  assert.equal(extractPathAt(line, at(line, "src/")), "src/app.ts");
+});
+
+test("剥掉只有行号的后缀", () => {
+  const line = "at frontend/src/api.ts:42";
+  assert.equal(extractPathAt(line, at(line, "frontend/")), "frontend/src/api.ts");
+});
+
+test("剥掉句末标点和包裹的括号", () => {
+  const line = "见 (report/summary.md).";
+  assert.equal(extractPathAt(line, at(line, "report/")), "report/summary.md");
+});
+
+test("引号里的路径可以带空格", () => {
+  const line = 'open "my docs/年度 报告.pdf" now';
+  assert.equal(extractPathAt(line, at(line, "my docs")), "my docs/年度 报告.pdf");
+});
+
+test("单引号同样处理", () => {
+  const line = "cat 'a b/c d.txt'";
+  assert.equal(extractPathAt(line, at(line, "a b/")), "a b/c d.txt");
+});
+
+test("点击引号之外不会误吞整段", () => {
+  const line = 'open "docs/a.md" and src/b.ts';
+  assert.equal(extractPathAt(line, at(line, "src/b")), "src/b.ts");
+});
+
+test("~ 开头的路径保留原样交给后端解析", () => {
+  const line = "config at ~/.config/app.toml";
+  assert.equal(extractPathAt(line, at(line, "~/")), "~/.config/app.toml");
+});
+
+test("没有扩展名也没有斜杠的普通词不当作路径", () => {
+  const line = "compiling successfully";
+  assert.equal(extractPathAt(line, at(line, "compiling")), null);
+});
+
+test("空白处点击返回 null", () => {
+  const line = "a.md   b.md";
+  assert.equal(extractPathAt(line, 5), null);
+});
+
+test("越界列返回 null", () => {
+  assert.equal(extractPathAt("a.md", -1), null);
+  assert.equal(extractPathAt("a.md", 99), null);
+});
+
+test("URL 不当作本地文件路径", () => {
+  const line = "see https://example.com/a.png";
+  assert.equal(extractPathAt(line, at(line, "https")), null);
+});
+
+test("TUI 框线不会被吞进路径", () => {
+  const line = "│ wrote out/a.png │";
+  assert.equal(extractPathAt(line, at(line, "out/")), "out/a.png");
+});
+
+test("行尾被截断的路径也按可见部分返回", () => {
+  const line = "reading src/very/deep/file.json";
+  assert.equal(extractPathAt(line, line.length - 1), "src/very/deep/file.json");
+});
+
+test("无扩展名但带斜杠的路径仍然接受", () => {
+  const line = "run scripts/build";
+  assert.equal(extractPathAt(line, at(line, "scripts/")), "scripts/build");
+});


### PR DESCRIPTION
## 需求

终端里打印出来的图片、文件要能双击预览；手机远程访问时要由后端代理源文件预览。

## 改动

双击（移动端双击轻点）终端里的文件路径 → 弹出预览层：

| 类型 | 行为 |
|---|---|
| 图片 png/jpg/jpeg/gif/webp/svg/avif/bmp/ico | 弹层内直接显示 |
| 文本 md/json/log/yaml/csv/各语言源码/无扩展名的 Dockerfile 等 | 纯文本渲染 |
| PDF | iframe 内联查看 |
| 其它 | 不预览，给「下载」 |

文件由后端代读（`GET /api/tasks/{id}/file?path=`），**手机远程访问走的就是同一个接口** —— 不需要客户端能访问那台机器的文件系统，也没有第二条代理链路。

### 安全边界

终端输出里的路径是命令行/模型打印出来的任意字符串，等同外部输入 —— 远程访问时一条 `cat /etc/passwd` 的回显就可能变成一个可点的读文件请求。因此：

- 只放行任务自己工作目录（`project.path`）内的文件，**以 realpath 为准**：`..` 逃逸、指向目录外的软链接一律 403
- 用 `relative_to`/`parents` 判定而非字符串前缀 —— `/work-secrets` 与 `/work` 前缀相同但不是子目录
- **文本一律按 `text/plain; charset=utf-8` 返回**：`.html`/`.svg` 按自身 MIME 内联就是在应用同源下执行 agent 刚写进工作目录的脚本
- 响应带 `X-Content-Type-Options: nosniff` 与 `Content-Security-Policy: default-src 'none'; sandbox`，直接在地址栏打开该 URL 也没有执行/取数能力
- 单文件上限 25MB，超出 413
- 接口在 `/api/*` 下，自动受全局鉴权中间件保护

### 文件

| 文件 | 作用 |
|---|---|
| `backend/app/task_files.py` | 路径解析、类型判定、响应 MIME（新增） |
| `backend/app/routers/tasks.py` | `GET /{task_id}/file` |
| `frontend/src/terminalFilePaths.ts` | 从终端行提取路径（新增） |
| `frontend/src/components/FilePreviewOverlay.tsx` | 预览弹层（新增） |
| `frontend/src/components/TerminalPanel.tsx` | 双击 / 双击轻点接入 |
| `frontend/src/api.ts` | `api.taskFile` |

路径提取处理了这些实际情况：软换行拆到下一行的路径、引号里带空格的路径、`src/a.ts:120:8` 的行列后缀、句末标点与包裹括号、TUI 竖线框线、宽字符占两列导致的列号≠字符串下标。URL 不当作本地文件（留给已有的链接处理）。

`TerminalPanel` 里把「按列号读取行字符簇」抽成了 `readLineClusters`，双击取路径与既有的长按选词共用 —— 是等价提取，没有改变选词行为。

## 验证

**1. 测试**

- `backend/tests/test_task_files.py` 21 例：相对/绝对/`./` 前缀路径、`..` 逃逸、**指向目录外的软链接**、**前缀相同的兄弟目录**（`/x` vs `/x-secrets`）、目录当文件、空路径、超限文件、各类型判定、`.html` 不按 HTML 返回
- `backend/tests/test_task_file_route.py` 10 例：图片保留自身 MIME、文本 UTF-8 纯文本、html 强制纯文本 + nosniff + sandbox、二进制强制 attachment、`download=true`、默认 inline、越界 403、`..` 403、不存在 404、任务不存在 404
- `frontend/tests/terminalFilePaths.test.ts` 17 例：路径提取的各种边界

```
backend:  119 passed, 1 failed
frontend: 21 pass, 0 fail
tsc -b --force: OK
vite build: ✓ built in 1.88s
```

唯一失败是 `test_browser_computer.py::test_runs_computer_loop_and_persists_screenshot`，原因 `BrowserType.launch: Executable doesn't exist`（playwright 浏览器未下载），**与本次改动无关的既有环境失败**。

**2. 真实浏览器实测**（Chrome，渲染本 PR 的 `FilePreviewOverlay`，四种状态逐个走过）

| 状态 | 结果 |
|---|---|
| 图片 `out/chart.png` | 正常显示，头部 `图片 · 29.6 KB`，下载/关闭按钮就位 |
| 文本 `docs/notes.md` | 正常渲染，**中文不乱码**，头部 `文本 · 95 B` |
| 二进制 `build/bundle.zip` | 显示「这个类型无法预览，用上方「下载」保存到本地。」 |
| 越界 `/etc/passwd` | 显示后端返回的「只能预览任务工作目录内的文件」 |

暗色样式与项目 `dh-*` 色板一致。

## 未验证

- **未做真机手机端双击轻点的实测**：双击轻点是自己按「两次轻点间隔 <320ms 且位移 <24px」判定的（iOS 上合成 dblclick 不可靠，因为 mousedown 已被拦），桌面 `dblclick` 路径已实测，移动端手感请你在真机上试一下。
- 未接入真实运行中的任务做端到端联调（需要一个真在跑的 CLI 任务），本轮以接口层集成测试 + 组件层浏览器实测覆盖。