### PR TITLE
fix: 谁在操作 PTY 就归谁，电脑端不再被手机端锁死在窄条里

### DIFF
--- a/backend/app/pty_session.py
+++ b/backend/app/pty_session.py
@@ -415,6 +415,10 @@ class PtySession:
         self.script_log_path: str | None = None
 
         self.proc: PtyProcess | None = None
+        # PTY 当前的 winsize，与 start() 里 spawn 的 dimensions 保持同步。
+        # resize 据此对同值请求短路：多端各自「认领」PTY 时会反复上报自己的网格，
+        # 无条件 setwinsize 会给 TUI 打出一串多余 SIGWINCH，每次都是一屏重绘。
+        self._winsize: tuple[int, int] | None = None
         self.subscribers: set[asyncio.Queue] = set()
         self.last_output = time.time()
         self._busy_until = 0.0
@@ -461,6 +465,7 @@ class PtySession:
         self.proc = PtyProcess.spawn(
             spawn_argv, cwd=self.cwd, env=env, dimensions=(30, 100)
         )
+        self._winsize = (30, 100)
         self._reader = threading.Thread(target=self._read_loop, daemon=True)
         self._reader.start()
         # 空闲巡检始终在跑：状态启发式(默认关)与催报兜底(默认开)各自内部把关
@@ -800,11 +805,14 @@ class PtySession:
         self.write(f"\x1b[200~{message}\x1b[201~\r")
 
     def resize(self, rows: int, cols: int) -> None:
+        if (rows, cols) == self._winsize:
+            return  # 尺寸没变就不碰 ioctl，避免无谓的 SIGWINCH 让 TUI 整屏重绘
         if self.proc is not None and self.proc.isalive():
             try:
                 self.proc.setwinsize(rows, cols)
             except Exception:
-                pass
+                return  # 没设成功就不记账，下次同值请求仍会重试
+            self._winsize = (rows, cols)
 
     def redraw(self, rows: int, cols: int) -> None:
         """Force a TUI repaint after replaying a bounded, partial terminal log."""

--- a/backend/tests/test_pty_resize_idempotent.py
+++ b/backend/tests/test_pty_resize_idempotent.py
@@ -1,0 +1,71 @@
+"""PTY winsize 的同值短路。
+
+多端同看一个任务时，各端在「自己正在被操作」时会反复认领 PTY（重发自己的网格）。
+若 resize 无条件 setwinsize，同值请求也会给 TUI 打出 SIGWINCH，每次都是一屏重绘。
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from app.pty_session import PtySession
+
+
+def _session_with_proc():
+    """绕开 start()，只装配 resize 需要的两个字段。"""
+    s = PtySession.__new__(PtySession)
+    s.proc = MagicMock()
+    s.proc.isalive.return_value = True
+    s._winsize = (30, 100)
+    return s
+
+
+class PtyResizeIdempotentTest(unittest.TestCase):
+    def test_same_size_does_not_touch_ioctl(self):
+        s = _session_with_proc()
+        s.resize(30, 100)
+        s.proc.setwinsize.assert_not_called()
+
+    def test_changed_size_is_applied_and_recorded(self):
+        s = _session_with_proc()
+        s.resize(24, 80)
+        s.proc.setwinsize.assert_called_once_with(24, 80)
+        self.assertEqual(s._winsize, (24, 80))
+        # 记账后，重复同值请求被短路
+        s.proc.setwinsize.reset_mock()
+        s.resize(24, 80)
+        s.proc.setwinsize.assert_not_called()
+
+    def test_rows_only_change_still_applies(self):
+        s = _session_with_proc()
+        s.resize(31, 100)
+        s.proc.setwinsize.assert_called_once_with(31, 100)
+
+    def test_failed_setwinsize_is_not_recorded(self):
+        """没设成功就不记账，否则下次同值请求会被错误短路，尺寸永远修不回来。"""
+        s = _session_with_proc()
+        s.proc.setwinsize.side_effect = OSError("boom")
+        s.resize(24, 80)
+        self.assertEqual(s._winsize, (30, 100))
+        s.proc.setwinsize.side_effect = None
+        s.resize(24, 80)
+        s.proc.setwinsize.assert_called_with(24, 80)
+        self.assertEqual(s._winsize, (24, 80))
+
+    def test_redraw_still_forces_a_repaint(self):
+        """redraw 靠 rows-1 → rows 两次真实变化强制重绘，不能被短路吃掉。"""
+        s = _session_with_proc()
+        s.redraw(30, 100)
+        self.assertEqual(
+            [c.args for c in s.proc.setwinsize.call_args_list],
+            [(29, 100), (30, 100)],
+        )
+
+    def test_dead_process_is_not_recorded(self):
+        s = _session_with_proc()
+        s.proc.isalive.return_value = False
+        s.resize(24, 80)
+        s.proc.setwinsize.assert_not_called()
+        self.assertEqual(s._winsize, (30, 100))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/components/TerminalPanel.tsx
+++ b/frontend/src/components/TerminalPanel.tsx
@@ -22,6 +22,8 @@ import { confirmDialog, promptDialog, toast } from "../overlay";
 import { guardQuota } from "../quota";
 import { TERMINAL_SUBMIT_KEY } from "../terminalInput";
 import { installHardWrappedWebLinkProvider } from "../terminalLinks";
+import type { ClaimState } from "../terminalClaim";
+import { shouldClaimViewport } from "../terminalClaim";
 import { extractPathAt } from "../terminalFilePaths";
 import { FilePreviewOverlay } from "./FilePreviewOverlay";
 import { STATUS_STYLE, taskStatusStyleKey } from "../theme";
@@ -856,7 +858,26 @@ function TerminalView({
     };
     connect();
 
-    term.onData((d) => wsRef.current?.readyState === WebSocket.OPEN && wsRef.current.send(d));
+    // 「谁在操作，PTY 就归谁」：本端被操作时把自己的网格重新写进 PTY。
+    // 多端共用一份 winsize，谁最后上报谁说了算；只在容器尺寸变化时上报的话，
+    // 手机端一连上就把 PTY 压窄，电脑端窗口没变、ResizeObserver 不触发，就再也抢
+    // 不回来，全屏 TUI 一直挤在左边窄条里。PTY 侧对同值 resize 做了短路，重复认领
+    // 不会打出多余的 SIGWINCH。
+    let lastClaim: ClaimState | null = null;
+    const claimViewport = () => {
+      if (wsRef.current?.readyState !== WebSocket.OPEN) return;
+      const grid = { rows: term.rows, cols: term.cols };
+      const now = Date.now();
+      if (!shouldClaimViewport(lastClaim, grid, now)) return;
+      lastClaim = { grid, at: now };
+      wsRef.current.send(`\x00resize:${grid.rows},${grid.cols}`);
+    };
+
+    term.onData((d) => {
+      if (wsRef.current?.readyState !== WebSocket.OPEN) return;
+      claimViewport(); // 本端正在被敲，PTY 就该按本端的宽度排版
+      wsRef.current.send(d);
+    });
     const scrollDisposable = term.onScroll((viewportY) => {
       if (disposed) return;
       if (applicationScrollActive) {
@@ -1254,7 +1275,10 @@ function TerminalView({
     document.addEventListener("selectionchange", maybeResumeDeferredWrites);
     // iOS PWA 锁屏/切后台会冻结页面：回来时的那次 flush 不该替几分钟前的手势补滚。
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") return;
+      if (document.visibilityState === "visible") {
+        claimViewport(); // 回到前台 = 用户把注意力挪回本端，按本端宽度排版
+        return;
+      }
       applicationScrollActive = false;
       stopApplicationScroll();
     };
@@ -1266,16 +1290,18 @@ function TerminalView({
       fit.fit();
       if (shouldRefocus) term.focus();
       scheduleScrollToBottom();
-      if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(`\x00resize:${term.rows},${term.cols}`);
-      }
+      claimViewport();
     };
     window.addEventListener("resize", onResize);
     // 容器高度变化（如折叠/展开上方详情面板）时也要 refit
     const ro = new ResizeObserver(onResize);
     ro.observe(elRef.current);
+    // 窗口获得焦点 = 用户把注意力挪到本端（页面回到前台走 onVisibilityChange）。
+    // 两端都静止时谁也不发，不会互相抢。
+    window.addEventListener("focus", claimViewport);
     return () => {
       disposed = true;
+      window.removeEventListener("focus", claimViewport);
       stopFling();
       cancelLongPress();
       stopApplicationScroll();

--- a/frontend/src/terminalClaim.ts
+++ b/frontend/src/terminalClaim.ts
@@ -1,0 +1,44 @@
+/** 「谁在操作，PTY 就归谁」——多端同看一个任务时的视口认领。
+ *
+ * 一个任务只有一个 PTY、一份 winsize，多端做不到各自一个尺寸。之前的做法是任一端
+ * 只在自己容器尺寸变化或刚连上时上报一次，于是谁最后上报谁说了算：手机端一连上就把
+ * PTY 压到手机宽度，电脑端的窗口尺寸没变、ResizeObserver 不触发，就再也抢不回来，
+ * 全屏 TUI 一直挤在左边窄条里，除非刷新页面或拖一下窗口。
+ *
+ * 改为在「本端正在被操作」时重新认领 PTY：有键盘输入、窗口获得焦点、页面回到前台。
+ * 语义可预期——你在哪台设备上动手，就按那台的宽度排版；两端都静止时谁也不动，
+ * 不会互相抢。PTY 侧对同值 resize 做了短路（pty_session.resize），认领是幂等的。
+ */
+
+export interface TerminalGrid {
+  rows: number;
+  cols: number;
+}
+
+/** 尺寸没变时两次认领的最小间隔。连续打字每个按键都发控制帧没有意义，
+ *  但间隔太长又会让「敲一下抢回来」变得迟钝；1s 下第一个按键即时生效。 */
+export const CLAIM_THROTTLE_MS = 1000;
+
+export interface ClaimState {
+  /** 上次认领时上报的网格 */
+  grid: TerminalGrid;
+  /** 上次认领的时间戳（performance.now / Date.now 同源即可） */
+  at: number;
+}
+
+/** 此刻是否应该把本端的网格重新写进 PTY。
+ *
+ * 尺寸变了必须立即上报——那是本端自己的排版需求，不能被节流压掉；
+ * 尺寸没变则是在跟另一端抢 PTY，按节流窗口放行。
+ */
+export function shouldClaimViewport(
+  last: ClaimState | null,
+  current: TerminalGrid,
+  now: number,
+  throttleMs: number = CLAIM_THROTTLE_MS,
+): boolean {
+  if (!(current.rows > 0 && current.cols > 0)) return false;
+  if (last === null) return true;
+  if (last.grid.rows !== current.rows || last.grid.cols !== current.cols) return true;
+  return now - last.at >= throttleMs;
+}

--- a/frontend/tests/terminalClaim.test.ts
+++ b/frontend/tests/terminalClaim.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { CLAIM_THROTTLE_MS, shouldClaimViewport } from "../src/terminalClaim.ts";
+
+const grid = (rows: number, cols: number) => ({ rows, cols });
+
+test("首次认领无条件放行", () => {
+  assert.equal(shouldClaimViewport(null, grid(30, 100), 0), true);
+});
+
+test("尺寸变了立即放行，不受节流压制", () => {
+  const last = { grid: grid(30, 100), at: 1000 };
+  // 距上次认领仅 1ms，远小于节流窗口
+  assert.equal(shouldClaimViewport(last, grid(30, 80), 1001), true);
+  assert.equal(shouldClaimViewport(last, grid(24, 100), 1001), true);
+});
+
+test("尺寸没变且在节流窗口内不重发", () => {
+  const last = { grid: grid(30, 100), at: 1000 };
+  assert.equal(shouldClaimViewport(last, grid(30, 100), 1000 + CLAIM_THROTTLE_MS - 1), false);
+});
+
+test("尺寸没变但已过节流窗口则放行——这是从另一端抢回 PTY 的路径", () => {
+  const last = { grid: grid(30, 100), at: 1000 };
+  assert.equal(shouldClaimViewport(last, grid(30, 100), 1000 + CLAIM_THROTTLE_MS), true);
+});
+
+test("节流窗口可配置", () => {
+  const last = { grid: grid(30, 100), at: 0 };
+  assert.equal(shouldClaimViewport(last, grid(30, 100), 50, 100), false);
+  assert.equal(shouldClaimViewport(last, grid(30, 100), 100, 100), true);
+});
+
+test("非法网格不认领——xterm 首帧未就绪时 rows/cols 可能为 0", () => {
+  assert.equal(shouldClaimViewport(null, grid(0, 100), 0), false);
+  assert.equal(shouldClaimViewport(null, grid(30, 0), 0), false);
+});


### PR DESCRIPTION
## 问题

一个任务只有一个 PTY、一份 winsize，多端做不到各自一个尺寸，**谁最后上报谁说了算**。

之前各端只在两个时机上报尺寸：容器尺寸变化（`ResizeObserver` / `window.resize`）和刚连上（`onopen`）。于是手机端一连上就把 PTY 压到手机宽度，而电脑端的窗口尺寸没变、`ResizeObserver` 不触发，就**再也抢不回来** —— 全屏 TUI 一直挤在左边窄条里，只能靠刷新页面或拖一下窗口才恢复。

键盘输入不在上报时机里（`onData` 只把字节送进 PTY），所以"在电脑上接着敲"并不能让它恢复。

## 方案

在「本端正在被操作」时重新认领 PTY：**键盘输入、窗口获得焦点、页面回到前台**。

语义可预期 —— 在哪台设备上动手，就按那台的宽度排版；两端都静止时谁也不发，不会互相抢。

### 改动

- **`pty_session.resize`：同值请求短路。** 认领是高频的，无条件 `setwinsize` 会给 TUI 打出一串多余 SIGWINCH，每次都是一屏重绘。`setwinsize` 失败不记账，否则下次同值请求会被错误短路、尺寸永远修不回来。`redraw` 靠 rows-1 → rows 两次真实变化，不受短路影响。
- **`terminalClaim.ts`：认领判定（纯函数）。** 尺寸变了立即上报（本端自己的排版需求，不能被节流压掉）；尺寸没变则是在跟另一端抢 PTY，按 1s 节流窗口放行 —— 连续打字不刷控制帧，但敲第一个键就能抢回来。
- **`TerminalPanel`**：`onData` / `window.focus` / `visibilitychange→visible` 三个触发点接上 `claimViewport()`；原来 `onResize` 里那段裸 send 也收敛到同一个函数。

## 验证证据

| 项 | 命令 | 结果 |
|---|---|---|
| TS 编译 + 构建 | `npm run build` | ✅ built in 1.89s，无 TS 报错 |
| 前端测试 | `npm test` | ✅ **27 passed / 0 failed**（21 旧 + 6 新） |
| 后端测试（本分支） | `cd backend && pytest tests -q --continue-on-collection-errors` | **83 passed** / 1 failed / 5 errors |
| 后端测试（main 基线） | 同上 | **77 passed** / 1 failed / 5 errors |

- passed +6 正是新增的 `test_pty_resize_idempotent.py`；`1 failed` 与 `5 errors` 两边**完全一致**，pre-existing，与本次改动无关。

**测试有效性已验证**（不是空转）：
- 去掉 `pty_session.resize` 的短路 → `test_same_size_does_not_touch_ioctl`、`test_changed_size_is_applied_and_recorded` 变红；还原后复绿。
- 把 `shouldClaimViewport` 的节流判断改成 `return true` → `尺寸没变且在节流窗口内不重发`、`节流窗口可配置` 变红；还原后复绿。

## 未覆盖

两端同时输入时会来回抢 PTY —— 这是方案本身的语义（谁在敲归谁），实际使用中不会同时敲。真机双端对照未跑，逻辑层由上述单测覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEcZNN6GDCQULYLcExjTpx